### PR TITLE
limit MaxTextureSlots size

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -261,6 +261,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
             GL.GetInteger(GetPName.MaxCombinedTextureImageUnits, out MaxTextureSlots);
             GraphicsExtensions.CheckGLError();
+            MaxTextureSlots = Math.Min(MaxTextureSlots, 16);
 
             GL.GetInteger(GetPName.MaxTextureSize, out _maxTextureSize);
             GraphicsExtensions.CheckGLError();


### PR DESCRIPTION
1) TextureColection uses a 32bit bitmask, therefore that's our hard limit
at the moment.
2) There are several places that loop over the texture collection.
Modern GPUs have hundreds of input slots and this is causing a performance issue.
3) This value should be limited by the Graphics profile.