### PR TITLE
Refactor SpriteFont Draw and MeasureString

### DIFF
--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -247,28 +247,28 @@ namespace Microsoft.Xna.Framework.Graphics
             if (rotation == 0f)
             {
                 item.Set(position.X - origin.X,
-                        position.Y - origin.Y,
-                        w,
-                        h,
-                        color,
-                        _texCoordTL,
-                        _texCoordBR,
-                        layerDepth);
+                         position.Y - origin.Y,
+                         w,
+                         h,
+                         layerDepth,
+                         color,
+                         _texCoordTL,
+                         _texCoordBR);
             }
             else
             {
                 item.Set(position.X,
-                        position.Y,
-                        -origin.X,
-                        -origin.Y,
-                        w,
-                        h,
-                        (float)Math.Sin(rotation),
-                        (float)Math.Cos(rotation),
-                        color,
-                        _texCoordTL,
-                        _texCoordBR,
-                        layerDepth);
+                         position.Y,
+                         -origin.X,
+                         -origin.Y,
+                         w,
+                         h,
+                         (float)Math.Sin(rotation),
+                         (float)Math.Cos(rotation),
+                         layerDepth,
+                         color,
+                         _texCoordTL,
+                         _texCoordBR);
             }
 
             FlushIfNeeded();
@@ -384,28 +384,28 @@ namespace Microsoft.Xna.Framework.Graphics
             if (rotation == 0f)
             {
                 item.Set(destinationRectangle.X - origin.X,
-                        destinationRectangle.Y - origin.Y,
-                        destinationRectangle.Width,
-                        destinationRectangle.Height,
-                        color,
-                        _texCoordTL,
-                        _texCoordBR,
-                        layerDepth);
+                         destinationRectangle.Y - origin.Y,
+                         destinationRectangle.Width,
+                         destinationRectangle.Height,
+                         layerDepth,
+                         color,
+                         _texCoordTL,
+                         _texCoordBR);
             }
             else
             {
                 item.Set(destinationRectangle.X,
-                        destinationRectangle.Y,
-                        -origin.X,
-                        -origin.Y,
-                        destinationRectangle.Width,
-                        destinationRectangle.Height,
-                        (float)Math.Sin(rotation),
-                        (float)Math.Cos(rotation),
-                        color,
-                        _texCoordTL,
-                        _texCoordBR,
-                        layerDepth);
+                         destinationRectangle.Y,
+                         -origin.X,
+                         -origin.Y,
+                         destinationRectangle.Width,
+                         destinationRectangle.Height,
+                         (float)Math.Sin(rotation),
+                         (float)Math.Cos(rotation),
+                         layerDepth,
+                         color,
+                         _texCoordTL,
+                         _texCoordBR);
             }
 
             FlushIfNeeded();
@@ -459,10 +459,10 @@ namespace Microsoft.Xna.Framework.Graphics
                      position.Y,
                      size.X,
                      size.Y,
+                     0,
                      color,
                      _texCoordTL,
-                     _texCoordBR,
-                     0);
+                     _texCoordBR);
 
             FlushIfNeeded();
         }
@@ -502,10 +502,10 @@ namespace Microsoft.Xna.Framework.Graphics
                      destinationRectangle.Y,
                      destinationRectangle.Width,
                      destinationRectangle.Height,
+                     0,
                      color,
                      _texCoordTL,
-                     _texCoordBR,
-                     0);
+                     _texCoordBR);
 
             FlushIfNeeded();
         }
@@ -530,10 +530,10 @@ namespace Microsoft.Xna.Framework.Graphics
                      position.Y,
                      texture.Width,
                      texture.Height,
+                     0,
                      color,
                      Vector2.Zero,
-                     Vector2.One,
-                     0);
+                     Vector2.One);
 
             FlushIfNeeded();
         }
@@ -558,10 +558,10 @@ namespace Microsoft.Xna.Framework.Graphics
                      destinationRectangle.Y,
                      destinationRectangle.Width,
                      destinationRectangle.Height,
+                     0,
                      color,
                      Vector2.Zero,
-                     Vector2.One,
-                     0);
+                     Vector2.One);
 
             FlushIfNeeded();
         }
@@ -656,10 +656,11 @@ namespace Microsoft.Xna.Framework.Graphics
                              p.Y,
                              pCurrentGlyph->BoundsInTexture.Width,
                              pCurrentGlyph->BoundsInTexture.Height,
+                             0,
                              color,
                              pCurrentGlyph->TexCoordTL,
-                             pCurrentGlyph->TexCoordBR,
-                             0);
+                             pCurrentGlyph->TexCoordBR
+                             );
 
                     offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
                 }
@@ -919,28 +920,28 @@ namespace Microsoft.Xna.Framework.Graphics
                     if (rotation == 0f)
                     {
                         item.Set(tpx,
-                                tpy,
-                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                color,
-                                _texCoordTL,
-                                _texCoordBR,
-                                layerDepth);
+                                 tpy,
+                                 pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                 pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                 layerDepth,
+                                 color,
+                                 _texCoordTL,
+                                 _texCoordBR);
                     }
                     else
                     {
                         item.Set(tpx,
-                                tpy,
-                                0,
-                                0,
-                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                sin,
-                                cos,
-                                color,
-                                _texCoordTL,
-                                _texCoordBR,
-                                layerDepth);
+                                 tpy,
+                                 0,
+                                 0,
+                                 pCurrentGlyph->BoundsInTexture.Width * scale.X,
+                                 pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                 sin,
+                                 cos,
+                                 layerDepth,
+                                 color,
+                                 _texCoordTL,
+                                 _texCoordBR);
                     }
 
                     offset.X += pCurrentGlyph->Width + pCurrentGlyph->RightSideBearing;
@@ -1144,28 +1145,27 @@ namespace Microsoft.Xna.Framework.Graphics
                     if (rotation == 0f)
                     {
                         item.Set(tpx,
-                                tpy,
-                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                color,
-                                _texCoordTL,
-                                _texCoordBR,
-                                layerDepth);
+                                 tpy,
+                                 pCurrentGlyph->BoundsInTexture.Width  * scale.X,
+                                 pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                 layerDepth,
+                                 color,
+                                 _texCoordTL, _texCoordBR);
                     }
                     else
                     {
                         item.Set(tpx,
-                                tpy,
-                                0,
-                                0,
-                                pCurrentGlyph->BoundsInTexture.Width * scale.X,
-                                pCurrentGlyph->BoundsInTexture.Height * scale.Y,
-                                sin,
-                                cos,
-                                color,
-                                _texCoordTL,
-                                _texCoordBR,
-                                layerDepth);
+                                 tpy,
+                                 0,
+                                 0,
+                                 pCurrentGlyph->BoundsInTexture.Width  * scale.X,
+                                 pCurrentGlyph->BoundsInTexture.Height * scale.Y,
+                                 sin,
+                                 cos,
+                                 layerDepth,
+                                 color,
+                                 _texCoordTL,
+                                 _texCoordBR);
                     }
 
                     offset.X += pCurrentGlyph->Width + (rtl ? pCurrentGlyph->LeftSideBearing : pCurrentGlyph->RightSideBearing);

--- a/MonoGame.Framework/Graphics/SpriteBatch.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatch.cs
@@ -598,7 +598,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.
@@ -757,7 +759,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.
@@ -941,7 +945,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.
@@ -1059,7 +1065,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.
@@ -1218,7 +1226,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.
@@ -1402,7 +1412,9 @@ namespace Microsoft.Xna.Framework.Graphics
                         continue;
                     }
 
-                    var currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    int currentGlyphIndex = spriteFont.GetGlyphIndexOrDefault(c);
+                    if (currentGlyphIndex == -1)
+                        throw new ArgumentException(SpriteFont.Errors.TextContainsUnresolvableCharacters, "text");
                     var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
                     // The first character on a line might have a negative left side bearing.

--- a/MonoGame.Framework/Graphics/SpriteBatchItem.cs
+++ b/MonoGame.Framework/Graphics/SpriteBatchItem.cs
@@ -7,57 +7,24 @@ using System;
 namespace Microsoft.Xna.Framework.Graphics
 {
     internal class SpriteBatchItem : IComparable<SpriteBatchItem>
-	{
-		public Texture2D Texture;
+    {
+        public Texture2D Texture;
         public float SortKey;
 
         public VertexPositionColorTexture vertexTL;
-		public VertexPositionColorTexture vertexTR;
-		public VertexPositionColorTexture vertexBL;
-		public VertexPositionColorTexture vertexBR;
-		public SpriteBatchItem ()
-		{
-			vertexTL = new VertexPositionColorTexture();
+        public VertexPositionColorTexture vertexTR;
+        public VertexPositionColorTexture vertexBL;
+        public VertexPositionColorTexture vertexBR;
+        public SpriteBatchItem()
+        {
+            vertexTL = new VertexPositionColorTexture();
             vertexTR = new VertexPositionColorTexture();
             vertexBL = new VertexPositionColorTexture();
-            vertexBR = new VertexPositionColorTexture();            
-		}
-		
-		public void Set ( float x, float y, float dx, float dy, float w, float h, float sin, float cos, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth )
-		{
-            // TODO, Should we be just assigning the Depth Value to Z?
-            // According to http://blogs.msdn.com/b/shawnhar/archive/2011/01/12/spritebatch-billboards-in-a-3d-world.aspx
-            // We do.
-			vertexTL.Position.X = x+dx*cos-dy*sin;
-            vertexTL.Position.Y = y+dx*sin+dy*cos;
-            vertexTL.Position.Z = depth;
-            vertexTL.Color = color;
-            vertexTL.TextureCoordinate.X = texCoordTL.X;
-            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
+            vertexBR = new VertexPositionColorTexture();
+        }
 
-			vertexTR.Position.X = x+(dx+w)*cos-dy*sin;
-            vertexTR.Position.Y = y+(dx+w)*sin+dy*cos;
-            vertexTR.Position.Z = depth;
-            vertexTR.Color = color;
-            vertexTR.TextureCoordinate.X = texCoordBR.X;
-            vertexTR.TextureCoordinate.Y = texCoordTL.Y;
-
-			vertexBL.Position.X = x+dx*cos-(dy+h)*sin;
-            vertexBL.Position.Y = y+dx*sin+(dy+h)*cos;
-            vertexBL.Position.Z = depth;
-            vertexBL.Color = color;
-            vertexBL.TextureCoordinate.X = texCoordTL.X;
-            vertexBL.TextureCoordinate.Y = texCoordBR.Y;
-
-			vertexBR.Position.X = x+(dx+w)*cos-(dy+h)*sin;
-            vertexBR.Position.Y = y+(dx+w)*sin+(dy+h)*cos;
-            vertexBR.Position.Z = depth;
-            vertexBR.Color = color;
-            vertexBR.TextureCoordinate.X = texCoordBR.X;
-            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
-		}
-
-        public void Set(float x, float y, float w, float h, Color color, Vector2 texCoordTL, Vector2 texCoordBR, float depth)
+        public void Set(float x, float y, float w, float h, float depth,
+                        Color color, Vector2 texCoordTL, Vector2 texCoordBR)
         {
             vertexTL.Position.X = x;
             vertexTL.Position.Y = y;
@@ -87,6 +54,39 @@ namespace Microsoft.Xna.Framework.Graphics
             vertexBR.TextureCoordinate.X = texCoordBR.X;
             vertexBR.TextureCoordinate.Y = texCoordBR.Y;
         }
+
+        public void Set(float x, float y, float dx, float dy, float w, float h, float sin, float cos, float depth,
+                        Color color, Vector2 texCoordTL, Vector2 texCoordBR)
+        {
+            vertexTL.Position.X = x + dx*cos-dy*sin;
+            vertexTL.Position.Y = y + dx*sin+dy*cos;
+            vertexTL.Position.Z = depth;
+            vertexTL.Color = color;
+            vertexTL.TextureCoordinate.X = texCoordTL.X;
+            vertexTL.TextureCoordinate.Y = texCoordTL.Y;
+
+            vertexTR.Position.X = x + (dx+w)*cos-dy*sin;
+            vertexTR.Position.Y = y + (dx+w)*sin+dy*cos;
+            vertexTR.Position.Z = depth;
+            vertexTR.Color = color;
+            vertexTR.TextureCoordinate.X = texCoordBR.X;
+            vertexTR.TextureCoordinate.Y = texCoordTL.Y;
+
+            vertexBL.Position.X = x + dx*cos-(dy+h)*sin;
+            vertexBL.Position.Y = y + dx*sin+(dy+h)*cos;
+            vertexBL.Position.Z = depth;
+            vertexBL.Color = color;
+            vertexBL.TextureCoordinate.X = texCoordTL.X;
+            vertexBL.TextureCoordinate.Y = texCoordBR.Y;
+
+            vertexBR.Position.X = x + (dx+w)*cos-(dy+h)*sin;
+            vertexBR.Position.Y = y + (dx+w)*sin+(dy+h)*cos;
+            vertexBR.Position.Z = depth;
+            vertexBR.Color = color;
+            vertexBR.TextureCoordinate.X = texCoordBR.X;
+            vertexBR.TextureCoordinate.Y = texCoordBR.Y;
+        }
+
 
         #region Implement IComparable
         public int CompareTo(SpriteBatchItem other)

--- a/MonoGame.Framework/Graphics/SpriteFont.cs
+++ b/MonoGame.Framework/Graphics/SpriteFont.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2022 Nick Kastellanos
+
 // Original code from SilverSprite Project
 using System;
 using System.Collections;
@@ -219,7 +221,10 @@ namespace Microsoft.Xna.Framework.Graphics
                     continue;
                 }
 
-                var currentGlyphIndex = GetGlyphIndexOrDefault(c);
+                int currentGlyphIndex = GetGlyphIndexOrDefault(c);
+                if (currentGlyphIndex == -1)
+                    throw new ArgumentException(Errors.TextContainsUnresolvableCharacters, "text");
+
                 Debug.Assert(currentGlyphIndex >= 0 && currentGlyphIndex < InternalGlyphs.Length, "currentGlyphIndex was outside the bounds of the array.");
                 var pCurrentGlyph = pGlyphs + currentGlyphIndex;
 
@@ -298,10 +303,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                if (_defaultGlyphIndex != -1)
-                    return _defaultGlyphIndex;
-                else
-                    throw new ArgumentException(Errors.TextContainsUnresolvableCharacters, "text");
+                return _defaultGlyphIndex;
             }
         }
         


### PR DESCRIPTION
resolve Glyph indexes in a single step.
10% faster MeasureString()
 