### PR TITLE
build GL effects under BlazorGL Platform.

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/EffectCompiler/ShaderProfile.OpenGL.cs
+++ b/MonoGame.Framework.Content.Pipeline/EffectCompiler/ShaderProfile.OpenGL.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.EffectCompiler
             {
                 case TargetPlatform.iOS:
                 case TargetPlatform.Android:
+                case TargetPlatform.BlazorGL:
                 case TargetPlatform.DesktopGL:
                 case TargetPlatform.MacOSX:
                 case TargetPlatform.RaspberryPi:


### PR DESCRIPTION
fix 'error : BlazorGL effects are not supported'