### PR TITLE
fix FontDescriptionProcessor.VerticalLineSpacing

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontDescriptionProcessor.cs
@@ -77,7 +77,9 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             var face = GlyphPacker.ArrangeGlyphs(font.Glyphs.Values, requiresPot, requiresSquare);
 
             // calculate line spacing.
-            output.VerticalLineSpacing = (int)(font.MetricsHeight + input.Spacing);
+            output.VerticalLineSpacing = (int)font.MetricsHeight;
+            // The LineSpacing from XNA font importer is +1px that SharpFont.
+            output.VerticalLineSpacing += 1;
 
             foreach (char ch in font.Glyphs.Keys)
             {
@@ -92,7 +94,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 cropping.X = glyph.XOffset + glyph.FontBitmapLeft;
                 cropping.Y = glyph.YOffset + font.MetricsAscender - (int)glyph.GlyphMetricTopBearing;
                 cropping.Width  = (int)glyph.XAdvance;
-                cropping.Height = (int)(font.MetricsHeight + input.Spacing);
+                cropping.Height = (int)(font.MetricsHeight);
                 output.Cropping.Add(cropping);
 
                 // Set the optional character kerning.

--- a/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
+++ b/MonoGame.Framework.Content.Pipeline/Processors/FontTextureProcessor.cs
@@ -52,13 +52,14 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
             }
 
             var glyphs = ExtractGlyphs((PixelBitmapContent<Color>)face);
-            // Optimize.
+
+            // Optimize glyphs.
             foreach (var glyph in glyphs)
-            {
                 glyph.Crop();
 
+            // calculate line spacing.
+            foreach (var glyph in glyphs)
                 output.VerticalLineSpacing = Math.Max(output.VerticalLineSpacing, glyph.Subrect.Height);
-            }
 
             // Get the platform specific texture profile.
             var texProfile = TextureProfile.ForPlatform(context.TargetPlatform);


### PR DESCRIPTION
FontDescription.Spacing apply to horizontal spacing.
Increase VerticalLineSpacing by 1px to match XNA.