### PR TITLE
move MaxTextureSlots to GraphicsCapabilities

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.Blazor.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.Blazor.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2023 Nick Kastellanos
+
 using System;
 
 
@@ -35,7 +37,16 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsHalfFloatTextures = device.GraphicsProfile >= GraphicsProfile.HiDef;
             SupportsNormalized = device.GraphicsProfile >= GraphicsProfile.HiDef;
             
-            SupportsVertexTextures = device.GraphicsProfile >= GraphicsProfile.HiDef;
+            _maxTextureSlots = 8;
+            _maxVertexTextureSlots = 0;
+            // fix for bad GL drivers
+            int maxCombinedTextureImageUnits;
+            maxCombinedTextureImageUnits = 8;
+            _maxTextureSlots = Math.Min(_maxTextureSlots, maxCombinedTextureImageUnits);
+            _maxVertexTextureSlots = Math.Min(_maxVertexTextureSlots, maxCombinedTextureImageUnits);
+            // limit texture slots to Reach profile limit until we implement profile detection.
+            _maxTextureSlots = Math.Min(_maxTextureSlots, 16);
+            _maxVertexTextureSlots = Math.Min(_maxTextureSlots, 0); // disable vertex textures until we implement it in WebGL.
 
             SupportsInstancing = false;
             //TNC: TODO: detect suport based on feture level

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.DirectX.cs
@@ -2,6 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2023 Nick Kastellanos
+
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     internal partial class GraphicsCapabilities
@@ -25,7 +28,8 @@ namespace Microsoft.Xna.Framework.Graphics
             SupportsTextureArrays = device.GraphicsProfile >= GraphicsProfile.FL10_0;
             SupportsDepthClamp = device.GraphicsProfile >= GraphicsProfile.HiDef;
 
-            SupportsVertexTextures = device.GraphicsProfile >= GraphicsProfile.FL10_0;
+            _maxTextureSlots = 16;
+            _maxVertexTextureSlots = (device.GraphicsProfile >= GraphicsProfile.FL10_0) ? 16 : 0;
 
             SupportsFloatTextures = device.GraphicsProfile >= GraphicsProfile.HiDef;
             SupportsHalfFloatTextures = device.GraphicsProfile >= GraphicsProfile.HiDef;

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.OpenGL.cs
@@ -2,6 +2,9 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2023 Nick Kastellanos
+
+using System;
 #if OPENGL
 using MonoGame.OpenGL;
 using GetParamName = MonoGame.OpenGL.GetPName;
@@ -115,7 +118,18 @@ namespace Microsoft.Xna.Framework.Graphics
 
             SupportsDepthClamp = GL.Extensions.Contains("GL_ARB_depth_clamp");
 
-            SupportsVertexTextures = false; // For now, until we implement vertex textures in OpenGL.
+            GL.GetInteger(GetPName.MaxTextureImageUnits, out _maxTextureSlots);
+            GraphicsExtensions.CheckGLError();
+            GL.GetInteger(GetPName.MaxVertexTextureImageUnits, out _maxVertexTextureSlots);
+            GraphicsExtensions.CheckGLError();
+            // fix for bad GL drivers
+            int maxCombinedTextureImageUnits;
+            GL.GetInteger(GetPName.MaxCombinedTextureImageUnits, out maxCombinedTextureImageUnits);
+            _maxTextureSlots = Math.Min(_maxTextureSlots, maxCombinedTextureImageUnits);
+            _maxVertexTextureSlots = Math.Min(_maxVertexTextureSlots, maxCombinedTextureImageUnits);
+            // limit texture slots to Reach profile limit until we implement profile detection.
+            _maxTextureSlots = Math.Min(_maxTextureSlots, 16);
+            _maxVertexTextureSlots = Math.Min(_maxTextureSlots, 0); // disable vertex textures until we implement it in WebGL.
 
             GL.GetInteger((GetPName)GetParamName.MaxSamples, out _maxMultiSampleCount);
 

--- a/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
+++ b/MonoGame.Framework/Graphics/GraphicsCapabilities.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2023 Nick Kastellanos
+
 using System;
 using System.Collections.Generic;
 
@@ -80,7 +82,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal bool SupportsDepthClamp { get; private set; }
 
-        internal bool SupportsVertexTextures { get; private set; }
+        private int _maxTextureSlots;
+        private int _maxVertexTextureSlots;
+
+        internal int MaxTextureSlots { get { return _maxTextureSlots; } }
+        internal int MaxVertexTextureSlots { get { return _maxVertexTextureSlots; } }
 
         /// <summary>
         /// True, if the underlying platform supports floating point textures. 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.Blazor.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.Blazor.cs
@@ -2,7 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-// Copyright (C)2022 Nick Kastellanos
+// Copyright (C)2023 Nick Kastellanos
 
 using System;
 using System.Collections.Generic;
@@ -213,8 +213,6 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsExtensions.GL = _glContext; // for GraphicsExtensions.CheckGLError()
             //_glContext = new LogContent(_glContext);
 
-            MaxTextureSlots = 8;
-            MaxVertexTextureSlots = 0;
 
             _maxTextureSize = 2048;
 
@@ -824,7 +822,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexConstantBuffers.Apply();
             _pixelConstantBuffers.Apply();
 
-            Textures.Apply();
+            VertexTextures.PlatformApply();
+            VertexSamplerStates.PlatformApply();
+            Textures.PlatformApply();
             SamplerStates.PlatformApply();
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -2,7 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-// Copyright (C)2022 Nick Kastellanos
+// Copyright (C)2023 Nick Kastellanos
 
 using System;
 using System.Collections.Generic;
@@ -91,9 +91,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSetup()
         {
-            MaxTextureSlots = 16;
-            MaxVertexTextureSlots = 16;
-
 			CreateDeviceIndependentResources();
 			CreateDeviceResources();
 
@@ -1230,9 +1227,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexConstantBuffers.Apply();
             _pixelConstantBuffers.Apply();
 
-            VertexTextures.Apply();
+            VertexTextures.PlatformApply();
             VertexSamplerStates.PlatformApply();
-            Textures.Apply();
+            Textures.PlatformApply();
             SamplerStates.PlatformApply();
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -2,7 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-// Copyright (C)2022 Nick Kastellanos
+// Copyright (C)2023 Nick Kastellanos
 
 using System;
 using System.Collections.Generic;
@@ -252,11 +252,6 @@ namespace Microsoft.Xna.Framework.Graphics
             var contextStrategy = new ConcreteGraphicsContext(this);
             _mainContext = new GraphicsContext(this, contextStrategy);
 #endif
-
-            GL.GetInteger(GetPName.MaxCombinedTextureImageUnits, out MaxTextureSlots);
-            GraphicsExtensions.CheckGLError();
-            MaxTextureSlots = Math.Min(MaxTextureSlots, 16);
-            MaxVertexTextureSlots = 0;
 
             GL.GetInteger(GetPName.MaxTextureSize, out _maxTextureSize);
             GraphicsExtensions.CheckGLError();
@@ -1065,7 +1060,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _vertexConstantBuffers.Apply();
             _pixelConstantBuffers.Apply();
 
-            Textures.Apply();
+            VertexTextures.PlatformApply();
+            VertexSamplerStates.PlatformApply();
+            Textures.PlatformApply();
             SamplerStates.PlatformApply();
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -154,8 +154,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal event EventHandler<PresentationEventArgs> PresentationChanged;
 
         private int _maxVertexBufferSlots;
-        internal int MaxTextureSlots;
-        internal int MaxVertexTextureSlots;
 
         public bool IsDisposed 
         { 
@@ -312,11 +310,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
             PlatformSetup();
 
-            Textures = new TextureCollection(this, ShaderStage.Pixel, MaxTextureSlots);
-            VertexTextures = new TextureCollection(this, ShaderStage.Vertex, MaxVertexTextureSlots);
+            GraphicsCapabilities = new GraphicsCapabilities();
+            GraphicsCapabilities.Initialize(this);
 
-            SamplerStates = new SamplerStateCollection(this, ShaderStage.Pixel, MaxTextureSlots);
-            VertexSamplerStates = new SamplerStateCollection(this, ShaderStage.Vertex, MaxVertexTextureSlots);
+            Textures = new TextureCollection(this, ShaderStage.Pixel, GraphicsCapabilities.MaxTextureSlots);
+            VertexTextures = new TextureCollection(this, ShaderStage.Vertex, GraphicsCapabilities.MaxVertexTextureSlots);
+
+            SamplerStates = new SamplerStateCollection(this, ShaderStage.Pixel, GraphicsCapabilities.MaxTextureSlots);
+            VertexSamplerStates = new SamplerStateCollection(this, ShaderStage.Vertex, GraphicsCapabilities.MaxVertexTextureSlots);
 
             _blendStateAdditive = BlendState.Additive.Clone();
             _blendStateAlphaBlend = BlendState.AlphaBlend.Clone();
@@ -339,9 +340,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Setup end
 
-            GraphicsCapabilities = new GraphicsCapabilities();
-            GraphicsCapabilities.Initialize(this);
-
             PlatformInitialize();
 
             // Force set the default render states.
@@ -352,13 +350,6 @@ namespace Microsoft.Xna.Framework.Graphics
             BlendState = BlendState.Opaque;
             DepthStencilState = DepthStencilState.Default;
             RasterizerState = RasterizerState.CullCounterClockwise;
-
-            // Clear the texture and sampler collections forcing
-            // the state to be reapplied.
-            VertexTextures.Clear();
-            VertexSamplerStates.Clear();
-            Textures.Clear();
-            SamplerStates.Clear();
 
             // Clear constant buffers
             _vertexConstantBuffers.Clear();
@@ -1013,7 +1004,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NotSupportedException("HiDef profile supports a maximum of 1048575 primitives per draw call.");
             if (this.GraphicsProfile == GraphicsProfile.Reach)
             {
-                for (int i = 0; i < MaxTextureSlots; i++)
+                for (int i = 0; i < GraphicsCapabilities.MaxTextureSlots; i++)
                 {
                     var tx2D = Textures[i] as Texture2D;
                     if (tx2D != null)
@@ -1075,7 +1066,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NotSupportedException("HiDef profile supports a maximum of 1048575 primitives per draw call.");
             if (this.GraphicsProfile == GraphicsProfile.Reach)
             {
-                for (int i = 0; i < MaxTextureSlots; i++)
+                for (int i = 0; i < GraphicsCapabilities.MaxTextureSlots; i++)
                 {
                     var tx2D = Textures[i] as Texture2D;
                     if (tx2D != null)
@@ -1124,7 +1115,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NotSupportedException("HiDef profile supports a maximum of 1048575 primitives per draw call.");
             if (this.GraphicsProfile == GraphicsProfile.Reach)
             {
-                for (int i = 0; i < MaxTextureSlots; i++)
+                for (int i = 0; i < GraphicsCapabilities.MaxTextureSlots; i++)
                 {
                     var tx2D = Textures[i] as Texture2D;
                     if (tx2D != null)
@@ -1212,7 +1203,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NotSupportedException("HiDef profile supports a maximum of 1048575 primitives per draw call.");
             if (this.GraphicsProfile == GraphicsProfile.Reach)
             {
-                for (int i = 0; i < MaxTextureSlots; i++)
+                for (int i = 0; i < GraphicsCapabilities.MaxTextureSlots; i++)
                 {
                     var tx2D = Textures[i] as Texture2D;
                     if (tx2D != null)
@@ -1311,7 +1302,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new NotSupportedException("HiDef profile supports a maximum of 1048575 primitives per draw call.");
             if (this.GraphicsProfile == GraphicsProfile.Reach)
             {
-                for (int i = 0; i < MaxTextureSlots; i++)
+                for (int i = 0; i < GraphicsCapabilities.MaxTextureSlots; i++)
                 {
                     var tx2D = Textures[i] as Texture2D;
                     if (tx2D != null)

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
@@ -34,9 +34,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformApply()
         {
-            if (!_device.GraphicsCapabilities.SupportsVertexTextures && _stage == ShaderStage.Vertex)
-                return;
-
             for (var i = 0; _d3dDirty != 0 && i < _actualSamplers.Length; i++)
             {
                 uint mask = ((uint)1) << i;

--- a/MonoGame.Framework/Graphics/TextureCollection.Blazor.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.Blazor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _targets[i] = 0;
         }
 
-        void PlatformApply()
+        internal void PlatformApply()
         {
             for (var i = 0; _dirty != 0 && i < _textures.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
@@ -28,9 +28,6 @@ namespace Microsoft.Xna.Framework.Graphics
                     ClearTargets(targets, device.CurrentD3DContext.PixelShader);
                     break;
                 case ShaderStage.Vertex:
-                    if (!device.GraphicsCapabilities.SupportsVertexTextures)
-                        return;
-
                     ClearTargets(targets, device.CurrentD3DContext.VertexShader);
                     break;
 
@@ -64,7 +61,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
         }
 
-        void PlatformApply()
+        internal void PlatformApply()
         {
             for (var i = 0; _dirty != 0 && i < _textures.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.OpenGL.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _targets[i] = 0;
         }
 
-        void PlatformApply()
+        internal void PlatformApply()
         {
             for (var i = 0; _dirty != 0 && i < _textures.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/TextureCollection.Ref.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.Ref.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Graphics
             throw new PlatformNotSupportedException();
         }
 
-        void PlatformApply()
+        internal void PlatformApply()
         {
             throw new PlatformNotSupportedException();
         }

--- a/MonoGame.Framework/Graphics/TextureCollection.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
             _textures = new Texture[capacity];
 
-            Dirty();
             PlatformInit();
+            PlatformClear();
+            Dirty();
         }
 
         public Texture this[int index]
@@ -38,9 +39,6 @@ namespace Microsoft.Xna.Framework.Graphics
             get { return _textures[index]; }
             set
             {
-                if (!_device.GraphicsCapabilities.SupportsVertexTextures && _stage == ShaderStage.Vertex)
-                    throw new NotSupportedException("Vertex textures are not supported on this device.");
-
                 if (_textures[index] != value)
                 {
                     uint mask = ((uint)1) << index;
@@ -68,12 +66,5 @@ namespace Microsoft.Xna.Framework.Graphics
                 _dirty |= (((uint)1) << i);
         }
 
-        internal void Apply()
-        {
-            if (_stage != ShaderStage.Vertex || _device.GraphicsCapabilities.SupportsVertexTextures)
-            {
-                PlatformApply();
-            }
-        }
     }
 }

--- a/MonoGame.Framework/Platform/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Platform/Graphics/OpenGL.cs
@@ -2,6 +2,8 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
+// Copyright (C)2023 Nick Kastellanos
+
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -17,6 +19,7 @@ using Matrix = Microsoft.Xna.Framework.Matrix;
 #if __IOS__ || __TVOS__
 using ObjCRuntime;
 #endif
+
 
 namespace MonoGame.OpenGL
 {
@@ -255,6 +258,7 @@ namespace MonoGame.OpenGL
     {
         ArrayBufferBinding = 0x8894,
         MaxTextureImageUnits = 0x8872,
+        MaxVertexTextureImageUnits = 0x8B4C,
         MaxCombinedTextureImageUnits = 0x8B4D,
         MaxVertexAttribs = 0x8869,
         MaxTextureSize = 0x0D33,


### PR DESCRIPTION
initialize GraphicsCapabilities earlier that
TextureCollection/SamplerStateCollection
normalize behaviour across platforms