### PR TITLE
fix BufferBindingInfo.GLVertexBuffer check

### DIFF
--- a/MonoGame.Framework/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/MonoGame.Framework/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -429,7 +429,7 @@ namespace Microsoft.Xna.Platform.Graphics
                 IntPtr vertexOffset = (IntPtr)(vertexDeclaration.VertexStride * (baseVertex + vertexBufferBinding.VertexOffset));
 
                 if (_attribsDirty
-                ||  _bufferBindingInfos[slot].GLVertexBuffer != vertexBufferBinding.VertexBuffer.Strategy.ToConcrete<ConcreteVertexBuffer>().GLVertexBuffer
+                ||  _bufferBindingInfos[slot].GLVertexBuffer != vertexBufferBinding.VertexBuffer.Strategy
                 ||  !ReferenceEquals(_bufferBindingInfos[slot].AttributeInfo, attrInfo)
                 ||  _bufferBindingInfos[slot].VertexOffset != vertexOffset
                 ||  _bufferBindingInfos[slot].InstanceFrequency != vertexBufferBinding.InstanceFrequency
@@ -465,10 +465,10 @@ namespace Microsoft.Xna.Platform.Graphics
                         }
                     }
 
-                    _bufferBindingInfos[slot].VertexOffset = vertexOffset;
+                    _bufferBindingInfos[slot].GLVertexBuffer = vertexBufferBinding.VertexBuffer.Strategy;
                     _bufferBindingInfos[slot].AttributeInfo = attrInfo;
+                    _bufferBindingInfos[slot].VertexOffset = vertexOffset;
                     _bufferBindingInfos[slot].InstanceFrequency = vertexBufferBinding.InstanceFrequency;
-                    _bufferBindingInfos[slot].GLVertexBuffer = vertexBufferBinding.VertexBuffer.Strategy.ToConcrete<ConcreteVertexBuffer>().GLVertexBuffer;
                 }
             }
 

--- a/MonoGame.Framework/Graphics/.BlazorGL/Vertices/VertexDeclarationAttributeInfo.cs
+++ b/MonoGame.Framework/Graphics/.BlazorGL/Vertices/VertexDeclarationAttributeInfo.cs
@@ -14,17 +14,25 @@ namespace Microsoft.Xna.Platform.Graphics
     // Holds information for caching
     internal class BufferBindingInfo
     {
+        private WeakReference _vertexBufferStrategyRef = new WeakReference(null);
+
         public VertexDeclarationAttributeInfo AttributeInfo;
         public IntPtr VertexOffset;
         public int InstanceFrequency;
-        public WebGLBuffer GLVertexBuffer;
 
-        public BufferBindingInfo(VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, WebGLBuffer glVertexBuffer)
+        public VertexBufferStrategy GLVertexBuffer
+        {
+            get { return (VertexBufferStrategy)_vertexBufferStrategyRef.Target; }
+            set { _vertexBufferStrategyRef.Target = value; }
+        }
+
+
+        public BufferBindingInfo(VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, VertexBufferStrategy vertexBufferStrategy)
         {
             AttributeInfo = attributeInfo;
             VertexOffset = vertexOffset;
             InstanceFrequency = instanceFrequency;
-            GLVertexBuffer = glVertexBuffer;
+            GLVertexBuffer = vertexBufferStrategy;
         }
 
         public override string ToString()

--- a/MonoGame.Framework/Graphics/.GL/ConcreteGraphicsContext.cs
+++ b/MonoGame.Framework/Graphics/.GL/ConcreteGraphicsContext.cs
@@ -472,7 +472,7 @@ namespace Microsoft.Xna.Platform.Graphics
                 IntPtr vertexOffset = (IntPtr)(vertexDeclaration.VertexStride * (baseVertex + vertexBufferBinding.VertexOffset));
 
                 if (_attribsDirty
-                ||  _bufferBindingInfos[slot].GLVertexBuffer != vertexBufferBinding.VertexBuffer.Strategy.ToConcrete<ConcreteVertexBuffer>().GLVertexBuffer
+                ||  _bufferBindingInfos[slot].GLVertexBuffer != vertexBufferBinding.VertexBuffer.Strategy
                 ||  !ReferenceEquals(_bufferBindingInfos[slot].AttributeInfo, attrInfo)
                 ||  _bufferBindingInfos[slot].VertexOffset != vertexOffset
                 ||  _bufferBindingInfos[slot].InstanceFrequency != vertexBufferBinding.InstanceFrequency
@@ -507,10 +507,10 @@ namespace Microsoft.Xna.Platform.Graphics
                         }
                     }
 
-                    _bufferBindingInfos[slot].VertexOffset = vertexOffset;
+                    _bufferBindingInfos[slot].GLVertexBuffer = vertexBufferBinding.VertexBuffer.Strategy;
                     _bufferBindingInfos[slot].AttributeInfo = attrInfo;
+                    _bufferBindingInfos[slot].VertexOffset = vertexOffset;
                     _bufferBindingInfos[slot].InstanceFrequency = vertexBufferBinding.InstanceFrequency;
-                    _bufferBindingInfos[slot].GLVertexBuffer = vertexBufferBinding.VertexBuffer.Strategy.ToConcrete<ConcreteVertexBuffer>().GLVertexBuffer;
                 }
             }
 

--- a/MonoGame.Framework/Graphics/.GL/ConcreteGraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/.GL/ConcreteGraphicsDevice.cs
@@ -162,7 +162,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
             _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos = new BufferBindingInfo[Capabilities.MaxVertexBufferSlots];
             for (int i = 0; i < _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos.Length; i++)
-                _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, -1);
+                _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, null);
         }
 
 
@@ -199,7 +199,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
             _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos = new BufferBindingInfo[this.Capabilities.MaxVertexBufferSlots];
             for (int i = 0; i < _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos.Length; i++)
-                _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, -1);
+                _mainContext.Strategy.ToConcrete<ConcreteGraphicsContext>()._bufferBindingInfos[i] = new BufferBindingInfo(null, IntPtr.Zero, 0, null);
 
 
             // Force set the default render states.

--- a/MonoGame.Framework/Graphics/.GL/Vertices/VertexDeclarationAttributeInfo.cs
+++ b/MonoGame.Framework/Graphics/.GL/Vertices/VertexDeclarationAttributeInfo.cs
@@ -14,17 +14,25 @@ namespace Microsoft.Xna.Platform.Graphics
     // Holds information for caching
     internal class BufferBindingInfo
     {
+        private WeakReference _vertexBufferStrategyRef = new WeakReference(null);
+
         public VertexDeclarationAttributeInfo AttributeInfo;
         public IntPtr VertexOffset;
         public int InstanceFrequency;
-        public int GLVertexBuffer;
 
-        public BufferBindingInfo(VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, int glVertexBuffer)
+        public VertexBufferStrategy GLVertexBuffer
+        {
+            get { return (VertexBufferStrategy)_vertexBufferStrategyRef.Target; }
+            set { _vertexBufferStrategyRef.Target = value; }
+        }
+
+
+        public BufferBindingInfo(VertexDeclarationAttributeInfo attributeInfo, IntPtr vertexOffset, int instanceFrequency, VertexBufferStrategy vertexBufferStrategy)
         {
             AttributeInfo = attributeInfo;
             VertexOffset = vertexOffset;
             InstanceFrequency = instanceFrequency;
-            GLVertexBuffer = glVertexBuffer;
+            GLVertexBuffer = vertexBufferStrategy;
         }
 
         public override string ToString()


### PR DESCRIPTION
checkinking the buffer id in PlatformApplyVertexBuffersAttribs is not
reliable.
OpenGL might return again a previously destroyed ids.