### PR TITLE
fix GL PlatformDeleteRenderTarget resource leak

### DIFF
--- a/MonoGame.Framework/Graphics/.BlazorGL/ConcreteTexture.cs
+++ b/MonoGame.Framework/Graphics/.BlazorGL/ConcreteTexture.cs
@@ -183,7 +183,6 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             var GL = contextStrategy.ToConcrete<ConcreteGraphicsContext>().GL;
 
-            if (renderTargetGL.GLColorBuffer != null)
             {
                 if (renderTargetGL.GLColorBuffer != null)
                 {

--- a/MonoGame.Framework/Graphics/.GL/ConcreteTexture.cs
+++ b/MonoGame.Framework/Graphics/.GL/ConcreteTexture.cs
@@ -440,35 +440,32 @@ namespace Microsoft.Xna.Platform.Graphics
 
         internal static void PlatformDeleteRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy)
         {
-            if (renderTargetGL.GLColorBuffer != 0)
+            contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindDisposeContext();
+            try
             {
-                contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindDisposeContext();
-                try
-                {
-                    var GL = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
+                var GL = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
 
-                    if (renderTargetGL.GLColorBuffer != 0)
-                    {
-                        GL.DeleteRenderbuffer(renderTargetGL.GLColorBuffer);
-                        GL.CheckGLError();
-                    }
-                    if (renderTargetGL.GLStencilBuffer != 0 && renderTargetGL.GLStencilBuffer != renderTargetGL.GLDepthBuffer)
-                    {
-                        GL.DeleteRenderbuffer(renderTargetGL.GLStencilBuffer);
-                        GL.CheckGLError();
-                    }
-                    if (renderTargetGL.GLDepthBuffer != 0)
-                    {
-                        GL.DeleteRenderbuffer(renderTargetGL.GLDepthBuffer);
-                        GL.CheckGLError();
-                    }
-
-                    contextStrategy.ToConcrete<ConcreteGraphicsContext>().PlatformUnbindRenderTarget(renderTargetGL);
-                }
-                finally
+                if (renderTargetGL.GLColorBuffer != 0)
                 {
-                    contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindDisposeContext();
+                    GL.DeleteRenderbuffer(renderTargetGL.GLColorBuffer);
+                    GL.CheckGLError();
                 }
+                if (renderTargetGL.GLStencilBuffer != 0 && renderTargetGL.GLStencilBuffer != renderTargetGL.GLDepthBuffer)
+                {
+                    GL.DeleteRenderbuffer(renderTargetGL.GLStencilBuffer);
+                    GL.CheckGLError();
+                }
+                if (renderTargetGL.GLDepthBuffer != 0)
+                {
+                    GL.DeleteRenderbuffer(renderTargetGL.GLDepthBuffer);
+                    GL.CheckGLError();
+                }
+
+                contextStrategy.ToConcrete<ConcreteGraphicsContext>().PlatformUnbindRenderTarget(renderTargetGL);
+            }
+            finally
+            {
+                contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindDisposeContext();
             }
         }
 


### PR DESCRIPTION
Depth and Stencil buffers are independent from the Color buffer.