### PR TITLE
revert PreserveAudioContentTypeReaders()

### DIFF
--- a/MonoGame.Framework/Audio/AudioService.cs
+++ b/MonoGame.Framework/Audio/AudioService.cs
@@ -59,7 +59,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         private AudioService()
         {
-            PreserveAudioContentTypeReaders();
+            //PreserveAudioContentTypeReaders();
 
             _strategy = AudioFactory.Current.CreateAudioServiceStrategy();
             _strategy.PlatformPopulateCaptureDevices(_microphones, ref _defaultMicrophone);
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Audio
 
         // Trick to prevent the linker removing the code, but not actually execute the code
         static bool _trimmingFalseFlag = false;
-        private static void PreserveAudioContentTypeReaders()
+        internal static void PreserveAudioContentTypeReaders()
         {
 #pragma warning disable 0219, 0649
             // Trick to prevent the linker removing the code, but not actually execute the code

--- a/MonoGame.Framework/Content/ContentTypeReaderManager.cs
+++ b/MonoGame.Framework/Content/ContentTypeReaderManager.cs
@@ -49,6 +49,7 @@ namespace Microsoft.Xna.Framework.Content
         internal ContentTypeReader[] LoadAssetReaders(ContentReader reader)
         {
             PreserveContentTypeReaders();
+            Microsoft.Xna.Framework.Audio.AudioService.PreserveAudioContentTypeReaders();
 
             // The first content byte i read tells me the number of content readers in this XNB file
             int numberOfReaders = reader.Read7BitEncodedInt();


### PR DESCRIPTION
fixes Link mode AOT on Android.
The cause is unknown. The same thing is working with
PreserveMediaContentTypeReaders()