### PR TITLE
Fixed resolve type bug due to splitting out to different assemblies

### DIFF
--- a/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
+++ b/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
@@ -237,6 +237,24 @@ namespace Microsoft.Xna.Framework.Content
                 return readerType;
 
             resolvedReaderTypeName = readerTypeName;
+            resolvedReaderTypeName = resolvedReaderTypeName.Replace(", MonoGame.Framework", string.Format(", {0}", ", Xna.Framework.Audio"));
+            readerType = Type.GetType(resolvedReaderTypeName);
+            if (readerType != null)
+                return readerType;
+
+            resolvedReaderTypeName = readerTypeName;
+            resolvedReaderTypeName = resolvedReaderTypeName.Replace(", MonoGame.Framework", string.Format(", {0}", "Xna.Framework.Media"));
+            readerType = Type.GetType(resolvedReaderTypeName);
+            if (readerType != null)
+                return readerType;
+
+            resolvedReaderTypeName = readerTypeName;
+            resolvedReaderTypeName = resolvedReaderTypeName.Replace(", MonoGame.Framework", string.Format(", {0}", "Xna.Framework.Graphics"));
+            readerType = Type.GetType(resolvedReaderTypeName);
+            if (readerType != null)
+                return readerType;
+
+            resolvedReaderTypeName = readerTypeName;
             resolvedReaderTypeName = readerTypeName + ", MonoGame.Framework";
             readerType = Type.GetType(resolvedReaderTypeName);
             if (readerType != null)


### PR DESCRIPTION
Calling ResolveReaderType in ContentTypeReaderManager would return null due to the resolvedReaderTypeName pointing to the wrong assembly. 