### PR TITLE
OnMouseDown and OnMouseUp set local variables

### DIFF
--- a/MonoGame.Framework/Input/.Blazor/ConcreteMouse.cs
+++ b/MonoGame.Framework/Input/.Blazor/ConcreteMouse.cs
@@ -93,18 +93,18 @@ namespace Microsoft.Xna.Platform.Input
         {
             _pos.X = x;
             _pos.Y = y;
-            ButtonState _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            ButtonState _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            ButtonState _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
         }
 
         private void OnMouseUp(object sender, int x, int y, int buttons)
         {
             _pos.X = x;
             _pos.Y = y;
-            ButtonState _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            ButtonState _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            ButtonState _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
         }
 
         public void OnMouseWheel(object sender, int deltaX, int deltaY, int deltaZ, int deltaMode)


### PR DESCRIPTION
 rather than the class instance variables as originally intended.