### PR TITLE
optimize ProcessMesh

### DIFF
--- a/src/Xna.Framework.Content.Pipeline.Graphics/Graphics/VertexContent.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/Graphics/VertexContent.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Graphics
             return vertexBuffer;
         }
 
-        private void SetupVertexDeclaration(VertexDeclarationContent vertexDeclaration)
+        internal void SetupVertexDeclaration(VertexDeclarationContent vertexDeclaration)
         {
             int offset = 0;
 

--- a/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
@@ -195,6 +195,10 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                         geometry.Vertices.SetupVertexDeclaration(geomBuffer.VertexDeclaration);
                         int stride = geomBuffer.VertexDeclaration.VertexStride.Value;
 
+                        if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
+                        ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)
+                            throw new InvalidOperationException("Invalid geometry");
+
                         int bufferOffset0 = 0;
                         geomBuffer.Write(bufferOffset0, stride, geometry.Vertices.Positions);
 
@@ -206,9 +210,6 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                             channelOffset += VertexBufferContent.SizeOf(channelType);
                         }
                         
-                        if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
-                        ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)
-                            throw new InvalidOperationException("Invalid geometry");
 
                         int bufferOffset = vertexBuffer.VertexData.Length;
                         vertexBuffer.Write(bufferOffset, 1, geomBuffer.VertexData);

--- a/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
@@ -191,7 +191,20 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     }
                     else
                     {
-                        VertexBufferContent geomBuffer = geometry.Vertices.CreateVertexBuffer();
+                        VertexBufferContent geomBuffer = new VertexBufferContent(geometry.Vertices.Positions.Count);
+                        geometry.Vertices.SetupVertexDeclaration(geomBuffer.VertexDeclaration);
+                        int stride = geomBuffer.VertexDeclaration.VertexStride.Value;
+
+                        int bufferOffset0 = 0;
+                        geomBuffer.Write(bufferOffset0, stride, geometry.Vertices.Positions);
+
+                        int channelOffset = VertexBufferContent.SizeOf(typeof(Vector3));
+                        foreach (VertexChannel channel in geometry.Vertices.Channels)
+                        {
+                            Type channelType = channel.ElementType;
+                            geomBuffer.Write(bufferOffset0 + channelOffset, stride, channelType, channel);
+                            channelOffset += VertexBufferContent.SizeOf(channelType);
+                        }
                         
                         if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
                         ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)

--- a/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
@@ -151,7 +151,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
         private ModelMeshContent ProcessMesh(MeshContent mesh, ModelBoneContent parent, ContentProcessorContext context)
         {
             List<ModelMeshPartContent> parts = new List<ModelMeshPartContent>();
-            VertexBufferContent vertexBuffer = new VertexBufferContent();
+            VertexBufferContent vertexBuffer = null;
             IndexCollection indexBuffer = new IndexCollection();
             
             if (GenerateTangentFrames)
@@ -185,21 +185,21 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                 }
                 else
                 {
-                    VertexBufferContent geomBuffer = geometry.Vertices.CreateVertexBuffer();
-
-                    // geometries are supposed to all have the same declaration, so just steal one of these
-                    if (vertexBuffer.VertexDeclaration.VertexStride == null 
-                    &&  vertexBuffer.VertexDeclaration.VertexElements.Count == 0)
+                    if (vertexBuffer == null)
                     {
-                        vertexBuffer.VertexDeclaration = geomBuffer.VertexDeclaration;
+                        vertexBuffer = geometry.Vertices.CreateVertexBuffer();
                     }
-                    
-                    if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
-                    ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)
-                        throw new InvalidOperationException("Invalid geometry");
+                    else
+                    {
+                        VertexBufferContent geomBuffer = geometry.Vertices.CreateVertexBuffer();
+                        
+                        if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
+                        ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)
+                            throw new InvalidOperationException("Invalid geometry");
 
-                    int bufferOffset = vertexBuffer.VertexData.Length;
-                    vertexBuffer.Write(bufferOffset, 1, geomBuffer.VertexData);
+                        int bufferOffset = vertexBuffer.VertexData.Length;
+                        vertexBuffer.Write(bufferOffset, 1, geomBuffer.VertexData);
+                    }
 
                     int startIndex = indexBuffer.Count;
                     indexBuffer.AddRange(geometry.Indices);

--- a/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/Processors/ModelProcessor.cs
@@ -191,28 +191,24 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Processors
                     }
                     else
                     {
-                        VertexBufferContent geomBuffer = new VertexBufferContent(geometry.Vertices.Positions.Count);
-                        geometry.Vertices.SetupVertexDeclaration(geomBuffer.VertexDeclaration);
-                        int stride = geomBuffer.VertexDeclaration.VertexStride.Value;
+                        VertexDeclarationContent vertexDeclaration = new VertexDeclarationContent();
+                        geometry.Vertices.SetupVertexDeclaration(vertexDeclaration);
+                        int stride = vertexDeclaration.VertexStride.Value;
 
-                        if (vertexBuffer.VertexDeclaration.VertexStride != geomBuffer.VertexDeclaration.VertexStride
-                        ||  vertexBuffer.VertexDeclaration.VertexElements.Count != geomBuffer.VertexDeclaration.VertexElements.Count)
+                        if (vertexBuffer.VertexDeclaration.VertexStride != vertexDeclaration.VertexStride
+                        ||  vertexBuffer.VertexDeclaration.VertexElements.Count != vertexDeclaration.VertexElements.Count)
                             throw new InvalidOperationException("Invalid geometry");
 
-                        int bufferOffset0 = 0;
-                        geomBuffer.Write(bufferOffset0, stride, geometry.Vertices.Positions);
+                        int bufferOffset0 = vertexBuffer.VertexData.Length;
+                        vertexBuffer.Write(bufferOffset0, stride, geometry.Vertices.Positions);
 
                         int channelOffset = VertexBufferContent.SizeOf(typeof(Vector3));
                         foreach (VertexChannel channel in geometry.Vertices.Channels)
                         {
                             Type channelType = channel.ElementType;
-                            geomBuffer.Write(bufferOffset0 + channelOffset, stride, channelType, channel);
+                            vertexBuffer.Write(bufferOffset0 + channelOffset, stride, channelType, channel);
                             channelOffset += VertexBufferContent.SizeOf(channelType);
                         }
-                        
-
-                        int bufferOffset = vertexBuffer.VertexData.Length;
-                        vertexBuffer.Write(bufferOffset, 1, geomBuffer.VertexData);
                     }
 
                     int startIndex = indexBuffer.Count;


### PR DESCRIPTION
create vertexBuffer directly from first geometry
avoid unnecessary copy of geomBuffer.VertexData