### PR TITLE
Implement ContentTypeReaderManager.AddTypeCreator from MonoGame

### DIFF
--- a/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
+++ b/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
@@ -40,6 +40,16 @@ namespace Microsoft.Xna.Framework.Content
 
         }
 
+        public static void AddTypeCreator(
+            string typeString,
+            Func<ContentTypeReader> createFunction)
+        {
+            var reader = createFunction();
+            var readerType = reader.GetType();
+            _contentTypeReadersCache.Add(typeString, readerType);
+            _contentReadersCache.Add(readerType, reader);
+        }
+
         public ContentTypeReader GetTypeReader(Type targetType)
         {
             if (targetType.IsArray && targetType.GetArrayRank() > 1)


### PR DESCRIPTION
The `ContentTypeReaderManager.AddTypeCreator` method is available in MonoGame, but was removed in kniEngine. This change re-implements the method in kniEngine to maintain compatibility with MonoGame.

The method allows custom content readers to be loaded without requiring reflection, and enables scenarios where the content reader is in the main executable rather than in an external assembly. In this scenario the assembly name containing the reader is not known at the time the content writer is invoked, so reflection (which requires an assembly name) fails to resolve the type.

Addresses issue #1796 