### PR TITLE
fix OpenAssetImporter

### DIFF
--- a/src/Xna.Framework.Content.Pipeline.Graphics/OpenAssetImporter.cs
+++ b/src/Xna.Framework.Content.Pipeline.Graphics/OpenAssetImporter.cs
@@ -279,7 +279,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                 // nodes shoud not be thrown away, meshes/materials should not be merged,
                 // etc. Custom model processors may depend on this information!
                 Scene aiScene = importer.ImportFile(filename,
-                    PostProcessSteps.FindDegenerates |
+                    //PostProcessSteps.FindDegenerates |
                     PostProcessSteps.FindInvalidData |
                     PostProcessSteps.FlipUVs |              // Required for Direct3D
                     PostProcessSteps.FlipWindingOrder |     // Required for Direct3D


### PR DESCRIPTION
after upgrading to Assimp v5.2.4 (#1305),
the FindDegenerates option removes small triangles from models