### PR TITLE
fix SensorBase.Dispose()

### DIFF
--- a/Platforms/Sensors/SensorBase.cs
+++ b/Platforms/Sensors/SensorBase.cs
@@ -72,9 +72,6 @@ namespace Microsoft.Devices.Sensors
 
         public void Dispose()
         {
-            if (_disposed)
-                throw new ObjectDisposedException(GetType().Name);
-
             Dispose(true);
             GC.SuppressFinalize(this);
         }


### PR DESCRIPTION
callingDispose() shouldn't throw DisposedException