### PR TITLE
rename Sensors namespace

### DIFF
--- a/Platforms/Devices/Sensors/.Android/ConcreteAccelerometer.cs
+++ b/Platforms/Devices/Sensors/.Android/ConcreteAccelerometer.cs
@@ -7,11 +7,11 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 using Android.Content;
 using Android.Hardware;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteAccelerometer : AccelerometerStrategy
     {

--- a/Platforms/Devices/Sensors/.Android/ConcreteCompass.cs
+++ b/Platforms/Devices/Sensors/.Android/ConcreteCompass.cs
@@ -6,11 +6,11 @@
 
 using System;
 using Microsoft.Xna.Framework;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 using Android.Content;
 using Android.Hardware;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteCompass : CompassStrategy
     {

--- a/Platforms/Devices/Sensors/.Android/ConcreteSensorService.cs
+++ b/Platforms/Devices/Sensors/.Android/ConcreteSensorService.cs
@@ -6,10 +6,10 @@
 
 using System;
 using System.Collections.Generic;
+using Microsoft.Xna.Framework.Devices.Sensors;
 using Android.Hardware;
-using Microsoft.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteSensorService : SensorServiceStrategy
     {

--- a/Platforms/Devices/Sensors/.Android/SensorListener.cs
+++ b/Platforms/Devices/Sensors/.Android/SensorListener.cs
@@ -3,7 +3,7 @@
 using System;
 using Android.Hardware;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class SensorListener : Java.Lang.Object, ISensorEventListener
     {

--- a/Platforms/Devices/Sensors/.iOS/ConcreteAccelerometer.cs
+++ b/Platforms/Devices/Sensors/.iOS/ConcreteAccelerometer.cs
@@ -7,11 +7,11 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 using CoreMotion;
 using Foundation;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteAccelerometer : AccelerometerStrategy
     {

--- a/Platforms/Devices/Sensors/.iOS/ConcreteCompass.cs
+++ b/Platforms/Devices/Sensors/.iOS/ConcreteCompass.cs
@@ -6,11 +6,11 @@
 
 using System;
 using Microsoft.Xna.Framework;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 using CoreMotion;
 using Foundation;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteCompass : CompassStrategy
     {

--- a/Platforms/Devices/Sensors/.iOS/ConcreteSensorService.cs
+++ b/Platforms/Devices/Sensors/.iOS/ConcreteSensorService.cs
@@ -6,9 +6,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     internal class ConcreteSensorService : SensorServiceStrategy
     {

--- a/Platforms/Devices/Sensors/Accelerometer.cs
+++ b/Platforms/Devices/Sensors/Accelerometer.cs
@@ -7,9 +7,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Platform.Devices.Sensors;
+using Microsoft.Xna.Platform.Devices.Sensors;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     /// <summary>
     /// Provides access to the device's accelerometer sensor.

--- a/Platforms/Devices/Sensors/AccelerometerFailedException.cs
+++ b/Platforms/Devices/Sensors/AccelerometerFailedException.cs
@@ -2,7 +2,7 @@
 // This file is subject to the terms and conditions defined in
 // file 'LICENSE.txt', which is part of this source code package.
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     /// <summary>
     /// The exception that may be thrown during a call to Start() or Stop(). The Message field describes the reason for the exception and the ErrorId field contains the error code from the underlying native code implementation of the accelerometer framework.

--- a/Platforms/Devices/Sensors/AccelerometerReading.cs
+++ b/Platforms/Devices/Sensors/AccelerometerReading.cs
@@ -5,7 +5,7 @@
 using System;
 using Microsoft.Xna.Framework;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public struct AccelerometerReading : ISensorReading
     {

--- a/Platforms/Devices/Sensors/AccelerometerStrategy.cs
+++ b/Platforms/Devices/Sensors/AccelerometerStrategy.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     public class AccelerometerStrategy : SensorStrategy<AccelerometerReading>
         , IDisposable

--- a/Platforms/Devices/Sensors/CalibrationEventArgs.cs
+++ b/Platforms/Devices/Sensors/CalibrationEventArgs.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     /// <summary>
     /// Provides data for Calibrate and events.

--- a/Platforms/Devices/Sensors/Compass.cs
+++ b/Platforms/Devices/Sensors/Compass.cs
@@ -6,9 +6,9 @@
 
 using System;
 using Microsoft.Xna.Framework;
-using Microsoft.Platform.Devices.Sensors;
+using Microsoft.Xna.Platform.Devices.Sensors;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     /// <summary>
     /// Provides access to the device's compass sensor.

--- a/Platforms/Devices/Sensors/CompassReading.cs
+++ b/Platforms/Devices/Sensors/CompassReading.cs
@@ -5,7 +5,7 @@
 using System;
 using Microsoft.Xna.Framework;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public struct CompassReading : ISensorReading
     {

--- a/Platforms/Devices/Sensors/CompassStrategy.cs
+++ b/Platforms/Devices/Sensors/CompassStrategy.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     public class CompassStrategy : SensorStrategy<CompassReading>
         , IDisposable

--- a/Platforms/Devices/Sensors/ISensorReading.cs
+++ b/Platforms/Devices/Sensors/ISensorReading.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public interface ISensorReading
     {

--- a/Platforms/Devices/Sensors/SensorBase.cs
+++ b/Platforms/Devices/Sensors/SensorBase.cs
@@ -7,7 +7,7 @@
 using System;
 using Microsoft.Xna.Framework;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public abstract class SensorBase<TSensorReading> : IDisposable
         where TSensorReading : ISensorReading

--- a/Platforms/Devices/Sensors/SensorFailedException.cs
+++ b/Platforms/Devices/Sensors/SensorFailedException.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public class SensorFailedException : Exception
     {

--- a/Platforms/Devices/Sensors/SensorReadingEventArgs.cs
+++ b/Platforms/Devices/Sensors/SensorReadingEventArgs.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public class SensorReadingEventArgs<T> : EventArgs
         where T : ISensorReading

--- a/Platforms/Devices/Sensors/SensorService.cs
+++ b/Platforms/Devices/Sensors/SensorService.cs
@@ -3,9 +3,9 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {   
     public sealed class SensorService : IDisposable
         , IPlatformSensorService

--- a/Platforms/Devices/Sensors/SensorServiceStrategy.cs
+++ b/Platforms/Devices/Sensors/SensorServiceStrategy.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     public interface IPlatformSensorService
     {

--- a/Platforms/Devices/Sensors/SensorState.cs
+++ b/Platforms/Devices/Sensors/SensorState.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace Microsoft.Devices.Sensors
+namespace Microsoft.Xna.Framework.Devices.Sensors
 {
     public enum SensorState
     {

--- a/Platforms/Devices/Sensors/SensorStrategy.cs
+++ b/Platforms/Devices/Sensors/SensorStrategy.cs
@@ -2,9 +2,9 @@
 
 using System;
 using System.Collections.Generic;
-using Microsoft.Devices.Sensors;
+using Microsoft.Xna.Framework.Devices.Sensors;
 
-namespace Microsoft.Platform.Devices.Sensors
+namespace Microsoft.Xna.Platform.Devices.Sensors
 {
     public class SensorStrategy<TSensorReading> : IDisposable
         where TSensorReading : ISensorReading


### PR DESCRIPTION
Microsoft.Devices.Sensors -> Microsoft.Xna.Framework.Devices.Sensors

Sensors was not part of XNA API. It was only available on Windows
Phone. This makes Sensors part of the framework.