### PR TITLE
fix IFrame eventc capture

### DIFF
--- a/Templates/VisualStudio2022/ProjectTemplates/BlazorGL.NetCore/wwwroot/index.html
+++ b/Templates/VisualStudio2022/ProjectTemplates/BlazorGL.NetCore/wwwroot/index.html
@@ -93,19 +93,19 @@
             window.requestAnimationFrame(tickJS);
         };
 
-        window.onkeydown = function(event)
+        window.addEventListener("keydown", function(event)
         {
             // Prevent Arrows Keys and Spacebar scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
                 event.preventDefault();
-        };
-        window.onmousewheel = function(event)
+        });
+        window.addEventListener("wheel", function(event)
         {
             // Prevent Mousewheel scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             event.preventDefault();
-        };
+        }, { passive: false });
     </script>
 </body>
 

--- a/Templates/VisualStudio2022/ProjectTemplates/Multiplatform.NetCore/BlazorGL/wwwroot/index.html
+++ b/Templates/VisualStudio2022/ProjectTemplates/Multiplatform.NetCore/BlazorGL/wwwroot/index.html
@@ -93,19 +93,19 @@
             window.requestAnimationFrame(tickJS);
         };
 
-        window.onkeydown = function(event)
+        window.addEventListener("keydown", function(event)
         {
             // Prevent Arrows Keys and Spacebar scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             if ([32, 37, 38, 39, 40].indexOf(event.keyCode) > -1)
                 event.preventDefault();
-        };
-        window.onmousewheel = function(event)
+        });
+        window.addEventListener("wheel", function(event)
         {
             // Prevent Mousewheel scrolling the outer page
             // when running inside an iframe. e.g: itch.io embedding.
             event.preventDefault();
-        };
+        }, { passive: false });
     </script>
 </body>
 


### PR DESCRIPTION
prevent arrow keys and mouse wheel events from bubbling out of the
iframe.
e.g: itch.io embedding.

fixes #1905