### PR TITLE
upgrade to SharpDX 4.2.0

### DIFF
--- a/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
+++ b/NuGetPackages/MonoGame.Framework.WindowsUniversal.nuspec
@@ -30,13 +30,13 @@
                 <dependency id="nkast.Xna.Framework.Devices" version="4.1.9001" />
                 <dependency id="nkast.Xna.Framework.Storage" version="4.1.9001" />
                 <dependency id="nkast.Xna.Framework.XR" version="4.1.9001" />
-                <dependency id="SharpDX" version="4.0.1" />
-                <dependency id="SharpDX.Direct2D1" version="4.0.1" />
-                <dependency id="SharpDX.Direct3D11" version="4.0.1" />
-                <dependency id="SharpDX.DXGI" version="4.0.1" />
-                <dependency id="SharpDX.XAudio2" version="4.0.1" />
-                <dependency id="SharpDX.MediaFoundation" version="4.0.1" />
-                <dependency id="SharpDX.XInput" version="4.0.1" />
+                <dependency id="SharpDX" version="4.2.0" />
+                <dependency id="SharpDX.Direct2D1" version="4.2.0" />
+                <dependency id="SharpDX.Direct3D11" version="4.2.0" />
+                <dependency id="SharpDX.DXGI" version="4.2.0" />
+                <dependency id="SharpDX.XAudio2" version="4.2.0" />
+                <dependency id="SharpDX.MediaFoundation" version="4.2.0" />
+                <dependency id="SharpDX.XInput" version="4.2.0" />
             </group>
         </dependencies>
 

--- a/Platforms/Kni.Platform.UAP.DX11.csproj
+++ b/Platforms/Kni.Platform.UAP.DX11.csproj
@@ -46,22 +46,22 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="SharpDX">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Direct2D1">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.Direct2D1.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.Direct2D1.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.Direct3D11">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.Direct3D11.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.Direct3D11.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.DXGI">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.DXGI.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.DXGI.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.MediaFoundation">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.MediaFoundation.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.MediaFoundation.dll</HintPath>
     </Reference>
     <Reference Include="SharpDX.XAudio2">
-      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.0.1\uap10.0\SharpDX.XAudio2.dll</HintPath>
+      <HintPath>..\ThirdParty\Dependencies\SharpDX\4.2.0\uap10.0\SharpDX.XAudio2.dll</HintPath>
     </Reference>
     <SDKReference Include="WindowsMobile, Version=10.0.19041.0">
       <Name>Windows Mobile Extensions for the UWP</Name>

--- a/Platforms/Kni.Platform.WinForms.DX11.OculusOVR.csproj
+++ b/Platforms/Kni.Platform.WinForms.DX11.OculusOVR.csproj
@@ -59,9 +59,9 @@
       <Private>False</Private>
     </ProjectReference>
     <PackageReference Include="nkast.LibOVR" Version="2.2.0" />
-    <PackageReference Include="SharpDX" Version="4.0.1" />
-    <PackageReference Include="SharpDX.DXGI" Version="4.0.1" />
-    <PackageReference Include="SharpDX.Direct3D11" Version="4.0.1" />
+    <PackageReference Include="SharpDX" Version="4.2.0" />
+    <PackageReference Include="SharpDX.DXGI" Version="4.2.0" />
+    <PackageReference Include="SharpDX.Direct3D11" Version="4.2.0" />
   </ItemGroup>
 
 </Project>

--- a/Platforms/Kni.Platform.WinForms.DX11.csproj
+++ b/Platforms/Kni.Platform.WinForms.DX11.csproj
@@ -38,13 +38,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Version="4.0.1" Include="SharpDX" />
-    <PackageReference Version="4.0.1" Include="SharpDX.Direct2D1" />
-    <PackageReference Version="4.0.1" Include="SharpDX.Direct3D11" />
-    <PackageReference Version="4.0.1" Include="SharpDX.DXGI" />
-    <PackageReference Version="4.0.1" Include="SharpDX.MediaFoundation" />
-    <PackageReference Version="4.0.1" Include="SharpDX.XAudio2" />
-    <PackageReference Version="4.0.1" Include="SharpDX.XInput" />
+    <PackageReference Version="4.2.0" Include="SharpDX" />
+    <PackageReference Version="4.2.0" Include="SharpDX.Direct2D1" />
+    <PackageReference Version="4.2.0" Include="SharpDX.Direct3D11" />
+    <PackageReference Version="4.2.0" Include="SharpDX.DXGI" />
+    <PackageReference Version="4.2.0" Include="SharpDX.MediaFoundation" />
+    <PackageReference Version="4.2.0" Include="SharpDX.XAudio2" />
+    <PackageReference Version="4.2.0" Include="SharpDX.XInput" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Kni.Tests.WinForms.DX11.csproj
+++ b/Tests/Kni.Tests.WinForms.DX11.csproj
@@ -34,8 +34,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Version="4.0.1" Include="SharpDX" />
-    <PackageReference Version="4.0.1" Include="SharpDX.DXGI" />
+    <PackageReference Version="4.2.0" Include="SharpDX" />
+    <PackageReference Version="4.2.0" Include="SharpDX.DXGI" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/src/Xna.Framework.Content.Pipeline.Graphics.MojoProcessor/XNA.Framework.Content.Pipeline.Graphics.MojoProcessor.csproj
+++ b/src/Xna.Framework.Content.Pipeline.Graphics.MojoProcessor/XNA.Framework.Content.Pipeline.Graphics.MojoProcessor.csproj
@@ -33,8 +33,8 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Version="4.0.1" Include="SharpDX" />
-    <PackageReference Version="4.0.1" Include="SharpDX.D3DCompiler" />
+    <PackageReference Version="4.2.0" Include="SharpDX" />
+    <PackageReference Version="4.2.0" Include="SharpDX.D3DCompiler" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
 -  CreateSampleGrabberSinkActivate(...) was removed in 'Use SharpGenTools.Sdk for Codegen ' https://github.com/sharpdx/SharpDX/pull/988 
 (A limitation of SharpGenTools.Sdk perhaps?) 
 