### PR TITLE
docs: fixed platform link in requirements document

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -1,4 +1,4 @@
-Depending on the [platform](Documentation/articles/platforms/0_platforms.md) that you are targeting, MonoGame has different sets of requirements.
+Depending on the [platform](Documentation/articles/platforms.md) that you are targeting, MonoGame has different sets of requirements.
 
 For desktop platforms
 ====================


### PR DESCRIPTION
Fixes an outdated link in the `REQUIREMENTS.md` to point to the platforms.md document.