### PR TITLE
fix parsing WMV metadata

### DIFF
--- a/src/Xna.Framework.Content.Pipeline.Media/VideoContent.cs
+++ b/src/Xna.Framework.Content.Pipeline.Media/VideoContent.cs
@@ -85,7 +85,8 @@ namespace Microsoft.Xna.Framework.Content.Pipeline
                         break;
 
                     case "bit_rate":
-                        _bitsPerSecond = int.Parse(value, CultureInfo.InvariantCulture);
+                        if (value != "N/A")
+                            _bitsPerSecond = int.Parse(value, CultureInfo.InvariantCulture);
                         break;
 
                     case "width":


### PR DESCRIPTION
bit_rate is not available in some WMV.

e.g. WMV produced by FFMPEG with
ffmpeg -i input.mp4 -c:v wmv2 -c:a wmav2 output.wmv