### PR TITLE
GraphicsResourceStrategy.Dispose()

### DIFF
--- a/src/Xna.Framework.Graphics/Graphics/GraphicsResourceStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsResourceStrategy.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Xna.Platform.Graphics
         GraphicsResource IGraphicsResourceStrategy.GraphicsResource
         {
             get { return _graphicsResourceRef.Target as GraphicsResource;}
-            set { _graphicsResourceRef.Target = value; }
+            set 
+            {
+                if (_graphicsResourceRef.Target != null || value != null)
+                    _graphicsResourceRef.Target = value;
+            }
         }
 
         internal GraphicsResourceStrategy()


### PR DESCRIPTION
similar to https://github.com/kniEngine/kni/pull/1559

prevents InvalidOperationException when setting WeakReference.Target to
null and the target is allready sceduled for collection.

fixes the issue with GUM editor
https://github.com/vchelaru/Gum/issues/749