### PR TITLE
Implements DrawInstancedPrimitives support for BlazorGL

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsCapabilities.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsCapabilities.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
             _maxVertexBufferSlots = (profile >= GraphicsProfile.FL10_1) ? 32 : 16;
 
-            SupportsInstancing = false;
+            SupportsInstancing = profile >= GraphicsProfile.HiDef;
             //TNC: TODO: detect suport based on feture level
             SupportsBaseIndexInstancing = false;
             SupportsSeparateBlendStates = true;

--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -622,9 +622,8 @@ namespace Microsoft.Xna.Platform.Graphics
                         // only set the divisor if instancing is supported
                         if (base.Capabilities.SupportsInstancing)
                         {
-                            throw new NotImplementedException();
-                            //GL2.VertexAttribDivisor(element.AttributeLocation, vertexBufferBinding.InstanceFrequency);
-                            //GL.CheckGLError();
+                            ((IWebGL2RenderingContext)GL).VertexAttribDivisor(element.AttributeLocation, vertexBufferBinding.InstanceFrequency);
+                            GL.CheckGLError();
                         }
                         else // If instancing is not supported, but InstanceFrequency of the buffer is not zero, throw an exception
                         {
@@ -841,7 +840,19 @@ namespace Microsoft.Xna.Platform.Graphics
             PlatformApplyIndexBuffer();
             PlatformApplyShaders();
 
-            throw new NotImplementedException();
+            WebGLDataType indexElementType = ((IPlatformIndexBuffer)Indices).Strategy.ToConcrete<ConcreteIndexBuffer>().DrawElementsType;
+            int indexOffsetInBytes = (startIndex * ((IPlatformIndexBuffer)Indices).Strategy.ElementSizeInBytes);
+            int indexElementCount = GraphicsContextStrategy.GetElementCountArray(primitiveType, primitiveCount);
+            WebGLPrimitiveType target = ConcreteGraphicsContext.PrimitiveTypeGL(primitiveType);
+
+            PlatformApplyVertexBuffers(baseVertex);
+
+            ((IWebGL2RenderingContext)GL).DrawElementsInstanced(target,
+                                                                indexElementCount,
+                                                                indexElementType,
+                                                                indexOffsetInBytes,
+                                                                instanceCount);
+            GL.CheckGLError();
 
             base.Metrics_AddDrawCount();
             base.Metrics_AddPrimitiveCount(primitiveCount * instanceCount);


### PR DESCRIPTION
Implements `DrawInstancedPrimitives` support for BlazorGL.

- This add support for WebGL2 only, which means `GraphicsProfile.HiDef` must be used.
- The `baseInstance` argument will have no effect as this is not supported by the WebGL2 `DrawElementsInstanced` method.