### PR TITLE
Fixes OpenAL default microphone selection

### DIFF
--- a/Platforms/Audio/OpenAL/ConcreteAudioService.cs
+++ b/Platforms/Audio/OpenAL/ConcreteAudioService.cs
@@ -236,7 +236,7 @@ namespace Microsoft.Xna.Platform.Audio
             string defaultDevice = OpenAL.ALC.GetString(_device, AlcGetString.CaptureDefaultDeviceSpecifier);
 
             // enumerating capture devices
-            IntPtr deviceList = OpenAL.ALC.alcGetString(_device, (int)AlcGetString.CaptureDeviceSpecifier);
+            IntPtr deviceList = OpenAL.ALC.alcGetString(IntPtr.Zero, (int)AlcGetString.CaptureDeviceSpecifier);
 
             // Marshal native UTF-8 character array to .NET string
             // The native string is a null-char separated list of known capture device specifiers ending with an empty string


### PR DESCRIPTION
Fixes OpenAL default microphone selection.

The `OpenAL.ALC.alcGetString` method (also referred to in another library here https://learn.microsoft.com/en-us/dotnet/api/opentk.audio.openal.alcgetstringlist) can either give:
- "the name of the specified capture device" (when given a pointer to an opened device), or
- "a list of all available capture devices if no capture device is specified" (when given `IntPtr.Zero`)

Currently the initialized output device is used with this method, and this results in no microphone being captured. Switching to `IntPtr.Zero` resolves this as it provides the correct list used to populate the available Microphone list, which is then used to select a default Microphone.