### PR TITLE
Adding DynamicSoundEffect support to BlazorGL

### DIFF
--- a/Platforms/Audio/Blazor/ConcreteAudioService.cs
+++ b/Platforms/Audio/Blazor/ConcreteAudioService.cs
@@ -18,7 +18,8 @@ namespace Microsoft.Xna.Platform.Audio
 
         internal ConcreteAudioService()
         {
-            Context = new AudioContext();
+            // Hardcode sample rate to 44,100Hz for now.
+            Context = new AudioContext(sampleRate: 44_100);
         }
 
         public override SoundEffectInstanceStrategy CreateSoundEffectInstanceStrategy(SoundEffectStrategy sfxStrategy)

--- a/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
@@ -124,18 +124,15 @@ namespace Microsoft.Xna.Platform.Audio
 
             unsafe
             {
-                // TODO: Fix submitting 2-channel buffer.
                 fixed (void* pBuffer = buffer)
                 {
                     short* pBuffer16 = (short*)pBuffer;
                     int destLength = count / 2;
                     var dest = new float[destLength];
-                    for (int c = 0; c < _channels; c++)
+                    
+                    for (int i = 0; i < destLength; i++)
                     {
-                        for (int i = 0; i < destLength; i++)
-                        {
-                            dest[i] = ((float)pBuffer16[i * _channels] / (float)short.MaxValue) * 2 - 1;
-                        }
+                        dest[i] = ((float)pBuffer16[i] / (float)short.MaxValue) * 2 - 1;
                     }
 
                     _dynamicSoundEffectNode.SubmitBuffer(dest);

--- a/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
@@ -4,9 +4,9 @@
 
 // Copyright (C)2021 Nick Kastellanos
 
-using System;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework.Audio;
+using nkast.Wasm.Audio;
+using System;
 
 namespace Microsoft.Xna.Platform.Audio
 {
@@ -16,7 +16,44 @@ namespace Microsoft.Xna.Platform.Audio
         private int _sampleRate;
         private int _channels;
 
+        private StreamingAudioWorkletNode _dynamicSoundEffectNode;
+
+        float _volume = 1f;
+
+        public override float Pan
+        {
+            get { return base.Pan; }
+            set
+            {
+                base.Pan = value;
+
+                if (_dynamicSoundEffectNode != null)
+                {
+                    _stereoPannerNode.Pan.SetTargetAtTime(value, 0, 0.05f);
+                }
+            }
+        }
+
+        public override float Volume
+        {
+            get { return base.Volume; }
+            set
+            {
+                base.Volume = value;
+
+                // XAct sound effects are not tied to the SoundEffect master volume.
+                float masterVolume = (!this.IsXAct) ? SoundEffect.MasterVolume : 1f;
+                _volume = value * masterVolume;
+
+                if (_dynamicSoundEffectNode != null)
+                {
+                    _gainNode.Gain.SetTargetAtTime(value * masterVolume, 0, 0.05f);
+                }
+            }
+        }
+
         private readonly WeakReference _dynamicSoundEffectInstanceRef = new WeakReference(null);
+
         DynamicSoundEffectInstance IDynamicSoundEffectInstanceStrategy.DynamicSoundEffectInstance
         {
             get { return _dynamicSoundEffectInstanceRef.Target as DynamicSoundEffectInstance; }
@@ -28,14 +65,13 @@ namespace Microsoft.Xna.Platform.Audio
         {
             _sampleRate = sampleRate;
             _channels = channels;
-
         }
 
         public int BuffersNeeded { get; set; }
 
         public int DynamicPlatformGetPendingBufferCount()
         {
-            throw new NotImplementedException();
+            return _dynamicSoundEffectNode?.QueuedBufferCount ?? int.MaxValue;
         }
 
         public override void PlatformPause()
@@ -45,7 +81,18 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformPlay(bool isLooped)
         {
-            throw new NotImplementedException();
+            AudioContext context = ConcreteAudioService.Context;
+
+            if (!context.IsInitialized)
+            {
+                throw new InvalidOperationException("AudioContext is not initialized yet for DynamicSoundEffect playback.");
+            }
+
+            _dynamicSoundEffectNode = context.CreateStreamingAudioWorkletNode(_channels);
+            _dynamicSoundEffectNode.Connect(_sourceTarget);
+
+            _gainNode.Gain.SetTargetAtTime(_volume, 0, 0);
+            _stereoPannerNode.Pan.SetTargetAtTime(base.Pan, 0, 0);
         }
 
         public override void PlatformResume(bool isLooped)
@@ -55,7 +102,10 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformStop()
         {
-            throw new NotImplementedException();
+            _dynamicSoundEffectNode.Stop();
+            _dynamicSoundEffectNode.Disconnect(_sourceTarget);
+            _dynamicSoundEffectNode.Dispose();
+            _dynamicSoundEffectNode = null;
         }
 
         public override void PlatformRelease(bool isLooped)
@@ -67,27 +117,57 @@ namespace Microsoft.Xna.Platform.Audio
 
         public void DynamicPlatformSubmitBuffer(byte[] buffer, int offset, int count, SoundState state)
         {
-            throw new NotImplementedException();
+            if (!ConcreteAudioService.Context.IsInitialized || _dynamicSoundEffectNode == null)
+            {
+                return;
+            }
+
+            unsafe
+            {
+                // TODO: Fix submitting 2-channel buffer.
+                fixed (void* pBuffer = buffer)
+                {
+                    short* pBuffer16 = (short*)pBuffer;
+                    int destLength = count / 2;
+                    var dest = new float[destLength];
+                    for (int c = 0; c < _channels; c++)
+                    {
+                        for (int i = 0; i < destLength; i++)
+                        {
+                            dest[i] = ((float)pBuffer16[i * _channels] / (float)short.MaxValue) * 2 - 1;
+                        }
+                    }
+
+                    _dynamicSoundEffectNode.SubmitBuffer(dest);
+                }
+            }
         }
 
         public void DynamicPlatformClearBuffers()
         {
-            throw new NotImplementedException();
+            if (!ConcreteAudioService.Context.IsInitialized || _dynamicSoundEffectNode == null)
+            {
+                return;
+            }
+
+            _dynamicSoundEffectNode.ClearBuffers();
         }
 
         public void DynamicPlatformUpdateBuffers()
         {
+            this.BuffersNeeded = Math.Max(0, 2 - DynamicPlatformGetPendingBufferCount());
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
-
+                if (_dynamicSoundEffectNode != null)
+                    _dynamicSoundEffectNode.Dispose();
             }
 
+            _dynamicSoundEffectNode = null;
             base.Dispose(disposing);
         }
-
     }
 }

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Xna.Platform.Audio
 
         AudioBufferSourceNode _bufferSource;
         bool _ended;
-        StereoPannerNode _stereoPannerNode;
-        GainNode _gainNode;
-        AudioNode _sourceTarget;
+        protected StereoPannerNode _stereoPannerNode;
+        protected GainNode _gainNode;
+        protected AudioNode _sourceTarget;
 
         float _volume = 1f;
 


### PR DESCRIPTION
This is just a starting point as there are still a few sticking points to address.  Namely:

* I couldn't find a sensible way of setting the `sampleRate` when creating a DynamicSoundEffect.  In BlazorGL, this needs to happen when the `AudioService` is created, which is well before the DSE creation is requested (if I understand correctly).
* `ConcreteDynamicSoundEffectInstance.DynamicPlatformGetPendingBufferCount()` returns `int.MaxValue` before `PlatformPlay()` is called for the first time.  The problem here is that the buffer count value is owned by the JS processor, but the JS processor can't be created in the DSE constructor.  Rather than returning 0 I chose to return `int.MaxValue`  to avoid blocking any code that loops until `DynamicPlatformGetPendingBufferCount()` returns a high enough value.
* AudioContext initialisation is asynchronous.  I couldn't find how to wait on a JS promise without deadlocking.