### PR TITLE
Implements Mouse.SetCursor for BlazorGL

### DIFF
--- a/Platforms/Input/.Blazor/ConcreteMouse.cs
+++ b/Platforms/Input/.Blazor/ConcreteMouse.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Xna.Platform.Input
 
         public override void PlatformSetCursor(MouseCursor cursor)
         {
-            throw new NotImplementedException();
+            BlazorGameWindow gameWindow = BlazorGameWindow.FromHandle(_wndHandle);
+            gameWindow._canvas.Cursor = ((IPlatformMouseCursor)cursor).GetStrategy<ConcreteMouseCursor>().CursorCSSPropertyValue;
         }
 
 

--- a/Platforms/Input/.Blazor/ConcreteMouseCursor.cs
+++ b/Platforms/Input/.Blazor/ConcreteMouseCursor.cs
@@ -7,13 +7,51 @@ namespace Microsoft.Xna.Platform.Input
 {
     public sealed class ConcreteMouseCursor : MouseCursorStrategy
     {
+        string _cursorCSSPropertyValue;
+
+        internal string CursorCSSPropertyValue { get { return _cursorCSSPropertyValue; } }
 
         public ConcreteMouseCursor(MouseCursorStrategy.MouseCursorType cursorType)
         {
             this._cursorType = cursorType;
             this._handle = IntPtr.Zero;
+
+            _cursorCSSPropertyValue = CursorTypeToCSSPropertyValue(cursorType);
         }
 
+        private string CursorTypeToCSSPropertyValue(MouseCursorStrategy.MouseCursorType cursorType)
+        {
+            switch (cursorType)
+            {
+                case MouseCursorStrategy.MouseCursorType.Arrow:
+                    return "default";
+                case MouseCursorStrategy.MouseCursorType.IBeam:
+                    return "text";
+                case MouseCursorStrategy.MouseCursorType.Wait:
+                    return "wait";
+                case MouseCursorStrategy.MouseCursorType.Crosshair:
+                    return "crosshair";
+                case MouseCursorStrategy.MouseCursorType.WaitArrow:
+                    return "progress";
+                case MouseCursorStrategy.MouseCursorType.SizeNWSE:
+                    return "nwse-resize";
+                case MouseCursorStrategy.MouseCursorType.SizeNESW:
+                    return "nesw-resize";
+                case MouseCursorStrategy.MouseCursorType.SizeWE:
+                    return "ew-resize";
+                case MouseCursorStrategy.MouseCursorType.SizeNS:
+                    return "ns-resize";
+                case MouseCursorStrategy.MouseCursorType.SizeAll:
+                    return "move";
+                case MouseCursorStrategy.MouseCursorType.No:
+                    return "not-allowed";
+                case MouseCursorStrategy.MouseCursorType.Hand:
+                    return "pointer";
+
+                default:
+                    throw new InvalidOperationException("cursorType");
+            }
+        }
 
         public ConcreteMouseCursor(byte[] data, int w, int h, int originx, int originy)
         {


### PR DESCRIPTION
Implements Mouse.SetCursor for BlazorGL in order to change the mouse icon.

This is to resolve issue #2344 (currently recent Gum changes mean the KNI.BlazorGL samples no longer work).

Here is some simple test code to demonstrate it working:

```
MouseCursorStrategy.MouseCursorType cursorType =
    (MouseCursorStrategy.MouseCursorType)(1 + ((int)gameTime.TotalGameTime.TotalSeconds % 12));
switch (cursorType)
{
    case MouseCursorStrategy.MouseCursorType.Arrow: Mouse.SetCursor(MouseCursor.Arrow); break;
    case MouseCursorStrategy.MouseCursorType.IBeam: Mouse.SetCursor(MouseCursor.IBeam); break;
    case MouseCursorStrategy.MouseCursorType.Wait: Mouse.SetCursor(MouseCursor.Wait); break;
    case MouseCursorStrategy.MouseCursorType.Crosshair: Mouse.SetCursor(MouseCursor.Crosshair); break;
    case MouseCursorStrategy.MouseCursorType.WaitArrow: Mouse.SetCursor(MouseCursor.WaitArrow); break;
    case MouseCursorStrategy.MouseCursorType.SizeNWSE: Mouse.SetCursor(MouseCursor.SizeNWSE); break;
    case MouseCursorStrategy.MouseCursorType.SizeNESW: Mouse.SetCursor(MouseCursor.SizeNESW); break;
    case MouseCursorStrategy.MouseCursorType.SizeWE: Mouse.SetCursor(MouseCursor.SizeWE); break;
    case MouseCursorStrategy.MouseCursorType.SizeNS: Mouse.SetCursor(MouseCursor.SizeNS); break;
    case MouseCursorStrategy.MouseCursorType.SizeAll: Mouse.SetCursor(MouseCursor.SizeAll); break;
    case MouseCursorStrategy.MouseCursorType.No: Mouse.SetCursor(MouseCursor.No); break;
    case MouseCursorStrategy.MouseCursorType.Hand: Mouse.SetCursor(MouseCursor.Hand); break;
}
```