### PR TITLE
check Shader model Version

### DIFF
--- a/Platforms/Graphics/.BlazorGL/Shader/ConcreteShader.cs
+++ b/Platforms/Graphics/.BlazorGL/Shader/ConcreteShader.cs
@@ -24,6 +24,15 @@ namespace Microsoft.Xna.Platform.Graphics
             if (profile != ShaderProfileType.OpenGL_Mojo)
                 throw new Exception("Effect profile '"+profile+"' is not compatible with the graphics backend '"+((IPlatformGraphicsContext)contextStrategy.Context).DeviceStrategy.Adapter.Backend+"'.");
 
+            GraphicsProfile graphicsProfile = this.GraphicsDeviceStrategy.GraphicsProfile;
+            ShaderVersion maxVersion = MaxShaderVersions[graphicsProfile];
+            if (shaderVersion != default
+            && shaderVersion > maxVersion)
+            {
+                throw new NotSupportedException(
+                    $"Shader model {shaderVersion} is not supported by the current graphics profile '{graphicsProfile}'.");
+            }
+
         }
 
         internal void CreateShader(GraphicsContextStrategy contextStrategy, WebGLShaderType shaderType, ShaderVersion shaderVersion, byte[] shaderBytecode)

--- a/Platforms/Graphics/.DX11/Shader/ConcreteShader.cs
+++ b/Platforms/Graphics/.DX11/Shader/ConcreteShader.cs
@@ -28,6 +28,14 @@ namespace Microsoft.Xna.Platform.Graphics
             if (profile != ShaderProfileType.DirectX_11)
                 throw new Exception("Effect profile '"+profile+"' is not compatible with the graphics backend '"+((IPlatformGraphicsContext)contextStrategy.Context).DeviceStrategy.Adapter.Backend+"'.");
 
+            GraphicsProfile graphicsProfile = this.GraphicsDeviceStrategy.GraphicsProfile;
+            ShaderVersion maxVersion = MaxShaderVersions[graphicsProfile];
+            if (shaderVersion != default
+            && shaderVersion > maxVersion)
+            {
+                throw new NotSupportedException(
+                    $"Shader model {shaderVersion} is not supported by the current graphics profile '{graphicsProfile}'.");
+            }
             // We need the bytecode later for allocating the
             // input layout from the vertex declaration.
             _shaderBytecode = shaderBytecode;

--- a/Platforms/Graphics/.GL/Shader/ConcreteShader.cs
+++ b/Platforms/Graphics/.GL/Shader/ConcreteShader.cs
@@ -29,6 +29,15 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             if (profile != ShaderProfileType.OpenGL_Mojo)
                 throw new Exception("Effect profile '"+profile+"' is not compatible with the graphics backend '"+((IPlatformGraphicsContext)contextStrategy.Context).DeviceStrategy.Adapter.Backend+"'.");
+            
+            GraphicsProfile graphicsProfile = this.GraphicsDeviceStrategy.GraphicsProfile;
+            ShaderVersion maxVersion = MaxShaderVersions[graphicsProfile];
+            if (shaderVersion != default
+            &&  shaderVersion > maxVersion)
+            {
+                throw new NotSupportedException(
+                    $"Shader model {shaderVersion} is not supported by the current graphics profile '{graphicsProfile}'.");
+            }
 
          }
 

--- a/src/Xna.Framework.Graphics/Graphics/Shader/ShaderStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/Shader/ShaderStrategy.cs
@@ -26,6 +26,15 @@ namespace Microsoft.Xna.Platform.Graphics
         public int[] CBuffers { get { return _CBuffers; } }
         public VertexAttribute[] Attributes { get { return _attributes; } }
 
+        protected static readonly Dictionary<GraphicsProfile, ShaderVersion> MaxShaderVersions = new Dictionary<GraphicsProfile, ShaderVersion>()
+        {
+            { GraphicsProfile.Reach,   new ShaderVersion(2, 0) },
+            { GraphicsProfile.HiDef,   new ShaderVersion(3, 0) },
+            { GraphicsProfile.FL10_0,  new ShaderVersion(4, 0) },
+            { GraphicsProfile.FL10_1,  new ShaderVersion(4, 1) },
+            { GraphicsProfile.FL11_0,  new ShaderVersion(5, 0) },
+            { GraphicsProfile.FL11_1,  new ShaderVersion(5, 0) },
+        };
 
         protected ShaderStrategy(GraphicsContextStrategy contextStrategy, ShaderVersion shaderVersion, byte[] shaderBytecode, SamplerInfo[] samplers, int[] cBuffers, VertexAttribute[] attributes, ShaderProfileType profile)
             : base(contextStrategy)


### PR DESCRIPTION
check shader model version if it's supported by the GraphicsProfile.

e.g. If you load a ps_4_0 , it is required to use GraphicsProfile.FL10_0 or higher.

This throws a better error than 
_SharpDX.SharpDXException: 'HRESULT: [0x80070057], Module: [General], ApiCode: [E_INVALIDARG/Invalid Arguments], Message: The parameter is incorrect._

This require changes to the FX format, to include ShaderVersion. It is not currently effective.