### PR TITLE
Implements BlazorGameWindow.OnTextInput

### DIFF
--- a/Platforms/Game/.Blazor/BlazorGameWindow.cs
+++ b/Platforms/Game/.Blazor/BlazorGameWindow.cs
@@ -173,6 +173,23 @@ namespace Microsoft.Xna.Framework
 
                 if (!_keys.Contains(xnakey))
                     _keys.Add(xnakey);
+
+                if (IsTextInputAttached())
+                {
+                    bool controlKeyBlocksTextInput = false;
+                    for (int i = 0; i < _keys.Count; i++)
+                    {
+                        Keys keyToCheck = _keys[i];
+                        if (keyToCheck == Keys.LeftControl || keyToCheck == Keys.RightControl || keyToCheck == Keys.LeftAlt)
+                        {
+                            controlKeyBlocksTextInput = true;
+                            break;
+                        }
+                    }
+
+                    if (key != '\0' && !controlKeyBlocksTextInput)
+                        OnTextInput(key, xnakey);
+                }
             };
             _window.OnKeyUp += (object sender, char key, int keyCode, int location) =>
             {

--- a/src/Xna.Framework.Game/GameWindow.cs
+++ b/src/Xna.Framework.Game/GameWindow.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Xna.Framework
         /// This event also supports key repeat.
         /// </summary>
         /// <remarks>
-        /// This event is only supported on desktop platforms.
+        /// This event is only supported on desktop/browser platforms.
         /// </remarks>
         public event EventHandler<TextInputEventArgs> TextInput;
 


### PR DESCRIPTION
Implements `GameWindow.OnTextInput` support for BlazorGL. The behavior is based on the existing desktop platforms implementations.

The control/alt key checks are to prevent text input events for shortcuts (for example with user code implementing `Ctrl`+`V` for paste, this shouldn't add the letter `v`). Again this matches desktop behavior, although I'm not 100% sure if there are more combinations to take into account (nothing comes to mind anyway).

Associated required Wasm changes are located here:
https://github.com/nkast/Wasm/pull/15