### PR TITLE
fix GL Clear(...)

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -108,16 +108,21 @@ namespace Microsoft.Xna.Platform.Graphics
             // So overwrite these states with what is needed to perform
             // the clear correctly and restore it afterwards.
             //
-            Rectangle prevScissorRect = this.ScissorRectangle;
             DepthStencilState prevDepthStencilState = this.DepthStencilState;
             BlendState prevBlendState = this.BlendState;
-            this.ScissorRectangle = _viewport.Bounds;
             // DepthStencilState.Default has the Stencil Test disabled; 
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
             this.DepthStencilState = _clearDepthStencilState;
             this.BlendState = BlendState.Opaque;
             PlatformApplyState();
+
+            if (_lastRasterizerState.ScissorTestEnable)
+            {
+                GL.Disable(WebGLCapability.SCISSOR_TEST);
+                GL.CheckGLError();
+                _lastRasterizerState.ScissorTestEnable = false;
+            }
 
             WebGLBufferBits bb = default(WebGLBufferBits);
             if ((options & ClearOptions.Target) != 0)
@@ -145,7 +150,6 @@ namespace Microsoft.Xna.Platform.Graphics
             base.Metrics_AddClearCount();
 
             // Restore the previous render state.
-            ScissorRectangle = prevScissorRect;
             DepthStencilState = prevDepthStencilState;
             BlendState = prevBlendState;
         }

--- a/Platforms/Graphics/.GL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.GL/ConcreteGraphicsContext.cs
@@ -158,16 +158,21 @@ namespace Microsoft.Xna.Platform.Graphics
             // So overwrite these states with what is needed to perform
             // the clear correctly and restore it afterwards.
             //
-            Rectangle prevScissorRect = this.ScissorRectangle;
             DepthStencilState prevDepthStencilState = this.DepthStencilState;
             BlendState prevBlendState = this.BlendState;
-            this.ScissorRectangle = _viewport.Bounds;
             // DepthStencilState.Default has the Stencil Test disabled; 
             // make sure stencil test is enabled before we clear since
             // some drivers won't clear with stencil test disabled
             this.DepthStencilState = _clearDepthStencilState;
             this.BlendState = BlendState.Opaque;
             PlatformApplyState();
+
+            if (_lastRasterizerState.ScissorTestEnable)
+            {
+                GL.Disable(EnableCap.ScissorTest);
+                GL.CheckGLError();
+                _lastRasterizerState.ScissorTestEnable = false;
+            }
 
             ClearBufferMask bufferMask = 0;
             if ((options & ClearOptions.Target) == ClearOptions.Target)
@@ -215,7 +220,6 @@ namespace Microsoft.Xna.Platform.Graphics
             base.Metrics_AddClearCount();
 
             // Restore the previous render state.
-            ScissorRectangle = prevScissorRect;
             DepthStencilState = prevDepthStencilState;
             BlendState = prevBlendState;
         }


### PR DESCRIPTION
When Scissor is enabled in RasterizerState,
clear() was affecting only the Viewport.

This fix implements the correct XNA behavior.
Clear will set the entire Backbuffer/RenderTarget and ignores the
Viewport & Scissor.