### PR TITLE
fix Android ConcreteMediaPlayerStrategy IsRepeating

### DIFF
--- a/Platforms/Media/Android/ConcreteMediaPlayer.cs
+++ b/Platforms/Media/Android/ConcreteMediaPlayer.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Xna.Platform.Media
                 }
 
                 _androidPlayer.Prepare();
-                _androidPlayer.Looping = this.PlatformIsRepeating;
                 _playingSong = song;
 
                 _androidPlayer.Start();


### PR DESCRIPTION
- fix setting IsRepeating to false after Play(...) didn't stop the loop.
- fix ActiveSongChanged and MediaStateChanged events were not firing.

Note: setting MediaPlayer.Looping didn't prevent the gap between loops.
to solve that we need to prepare the next loop on a second MediaPlayer
and call .SetNextMediaPlayer(...)