### PR TITLE
enable DX Keyboard Input by default when there is no GameWindow/Game.

### DIFF
--- a/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
+++ b/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
@@ -153,6 +153,9 @@ namespace Microsoft.Xna.Framework
             if (TouchPanel.WindowHandle == IntPtr.Zero)
                 TouchPanel.WindowHandle = this.Handle;
 
+            // disable Keyboard input until the window is activated.
+            ((IPlatformKeyboard)Keyboard.Current).GetStrategy<ConcreteKeyboard>().SetActive(false);
+
             Form.Activated += OnActivated;
             Form.Deactivate += OnDeactivate;
             Form.ResizeBegin += OnResizeBegin;
@@ -418,6 +421,9 @@ namespace Microsoft.Xna.Framework
                 Mouse.WindowHandle = IntPtr.Zero;
             if (TouchPanel.WindowHandle == this.Handle)
                 TouchPanel.WindowHandle = IntPtr.Zero;
+
+            // re-enable keyboard input.
+            ((IPlatformKeyboard)Keyboard.Current).GetStrategy<ConcreteKeyboard>().SetActive(true);
 
             _instances.Remove(this.Handle);
             _handle = IntPtr.Zero;

--- a/Platforms/Input/.WindowsDX/ConcreteKeyboard.cs
+++ b/Platforms/Input/.WindowsDX/ConcreteKeyboard.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Xna.Platform.Input
 
         private readonly List<Keys> _keys = new List<Keys>(10);
 
-        private bool _isActive;
+        private bool _isActive = true;
 
         [DllImport("user32.dll")]
         private static extern bool GetKeyboardState(byte[] lpKeyState);


### PR DESCRIPTION
This is useful when KNI's GraphicsDevice  is embeded  in a WPF/WinForms
editor.

This should fix
https://github.com/vchelaru/Gum/issues/1537#issuecomment-3384241359