### PR TITLE
Fixes updating BlazorGameWindow.ClientBounds & mouse/touch positions

### DIFF
--- a/Platforms/Game/.Blazor/BlazorGameWindow.cs
+++ b/Platforms/Game/.Blazor/BlazorGameWindow.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Xna.Framework
 
         private readonly List<Keys> _keys = new List<Keys>();
 
+        private Rectangle _clientBounds;
         private Point _locationBeforeFullScreen;
 
         // flag to indicate that we're switching to/from full screen and should ignore resize events
@@ -56,13 +57,7 @@ namespace Microsoft.Xna.Framework
 
         public override string ScreenDeviceName { get { return String.Empty; } }
 
-        public override Rectangle ClientBounds
-        {
-            get
-            {
-                return new Rectangle(0, 0, _canvas.Width, _canvas.Height);
-            }
-        }
+        public override Rectangle ClientBounds { get { return _clientBounds; } }
 
         public override bool AllowUserResizing
         {
@@ -107,6 +102,7 @@ namespace Microsoft.Xna.Framework
 
         #endregion
 
+        internal Div _canvasHolder { get; private set; }
         internal Canvas _canvas { get; private set; }
         internal Window wasmWindow { get { return _window; } }
 
@@ -115,6 +111,7 @@ namespace Microsoft.Xna.Framework
             _concreteGame = concreteGame;
 
             _window = Window.Current;
+            _canvasHolder = _window.Document.GetElementById<Div>("canvasHolder");
             _canvas = _window.Document.GetElementById<Canvas>("theCanvas");
             _instances.Add(this.Handle, this);
 
@@ -222,9 +219,11 @@ namespace Microsoft.Xna.Framework
             // Form.Resize += OnResize;
             //  Form.ResizeBegin += OnResizeBegin;
             //  Form.ResizeEnd += OnResizeEnd;
-            _window.OnResize += OnResize;
 
-           // Form.KeyPress += OnKeyPress;
+            // Form.KeyPress += OnKeyPress;
+
+            UpdateClientBounds();
+            ((IFrameworkDispatcher)FrameworkDispatcher.Current).OnUpdate += UpdateClientBounds;
         }
 
         private void SetIcon()
@@ -270,14 +269,6 @@ namespace Microsoft.Xna.Framework
             }
         }
 
-        internal void OnResize(object sender)
-        {
-
-            UpdateBackBufferSize();
-
-            OnClientSizeChanged();
-        }
-
         // TODO: move UpdateBackBufferSize() in graphicsDeviceManager
         private void UpdateBackBufferSize()
         {
@@ -287,8 +278,8 @@ namespace Microsoft.Xna.Framework
                 if (gdm.GraphicsDevice == null)
                     return;
 
-                _canvas.Width = _window.InnerWidth;
-                _canvas.Height = _window.InnerHeight;
+                _canvas.Width = _clientBounds.Width;
+                _canvas.Height = _clientBounds.Height;
 
                 int newWidth  = _canvas.Width;
                 int newHeight = _canvas.Height;
@@ -311,6 +302,23 @@ namespace Microsoft.Xna.Framework
         internal void ChangeClientSize(int width, int height)
         {
 
+        }
+
+        private void UpdateClientBounds()
+        {
+            DOMRect boundingClientRect = _canvasHolder.GetBoundingClientRect();
+            int width = (int)boundingClientRect.Width;
+            int height = (int)boundingClientRect.Height;
+
+            bool resized = width != _clientBounds.Width || height != _clientBounds.Height;
+
+            _clientBounds = new Rectangle((int)boundingClientRect.X, (int)boundingClientRect.Y, width, height);
+
+            if (resized)
+            {
+                UpdateBackBufferSize();
+                OnClientSizeChanged();
+            }
         }
 
         #region Public Methods
@@ -337,6 +345,8 @@ namespace Microsoft.Xna.Framework
             _canvas = null;
 
             _concreteGame = null;
+
+            ((IFrameworkDispatcher)FrameworkDispatcher.Current).OnUpdate -= UpdateClientBounds;
         }
 
         public void MouseVisibleToggled()

--- a/Platforms/Input/.Blazor/ConcreteMouse.cs
+++ b/Platforms/Input/.Blazor/ConcreteMouse.cs
@@ -88,14 +88,12 @@ namespace Microsoft.Xna.Platform.Input
 
         private void OnMouseMove(object sender, int x, int y)
         {
-            _pos.X = x;
-            _pos.Y = y;
+            UpdateMousePosition(x, y);
         }
 
         private void OnMouseDown(object sender, int x, int y, int buttons)
         {
-            _pos.X = x;
-            _pos.Y = y;
+            UpdateMousePosition(x, y);
             _leftButton   = ((buttons &  1) != 0) ? ButtonState.Pressed : ButtonState.Released;
             _rightButton  = ((buttons &  2) != 0) ? ButtonState.Pressed : ButtonState.Released;
             _middleButton = ((buttons &  4) != 0) ? ButtonState.Pressed : ButtonState.Released;
@@ -105,8 +103,7 @@ namespace Microsoft.Xna.Platform.Input
 
         private void OnMouseUp(object sender, int x, int y, int buttons)
         {
-            _pos.X = x;
-            _pos.Y = y;
+            UpdateMousePosition(x, y);
             _leftButton   = ((buttons &  1) != 0) ? ButtonState.Pressed : ButtonState.Released;
             _rightButton  = ((buttons &  2) != 0) ? ButtonState.Pressed : ButtonState.Released;
             _middleButton = ((buttons &  4) != 0) ? ButtonState.Pressed : ButtonState.Released;
@@ -121,5 +118,11 @@ namespace Microsoft.Xna.Platform.Input
             _scrollY -= Math.Sign(deltaY) * wheelDelta;
         }
 
+        private void UpdateMousePosition(int x, int y)
+        {
+            BlazorGameWindow gameWindow = BlazorGameWindow.FromHandle(_wndHandle);
+            _pos.X = x - gameWindow.ClientBounds.X;
+            _pos.Y = y - gameWindow.ClientBounds.Y;
+        }
     }
 }

--- a/Platforms/Input/.Blazor/Touch/ConcreteTouchPanel.cs
+++ b/Platforms/Input/.Blazor/Touch/ConcreteTouchPanel.cs
@@ -77,10 +77,10 @@ namespace Microsoft.Xna.Platform.Input.Touch
             if (wndHandle != IntPtr.Zero)
             {
                 GameWindow gameWindow = BlazorGameWindow.FromHandle(wndHandle);
-                Rectangle windowsBounds = gameWindow.ClientBounds;
-                Point winSize = new Point(windowsBounds.Width, windowsBounds.Height);
+                Rectangle clientBounds = gameWindow.ClientBounds;
+                Vector2 positionWithinBounds = position - clientBounds.Location.ToVector2();
 
-                base.AddPressedEvent(nativeTouchId, position, winSize);
+                base.AddPressedEvent(nativeTouchId, positionWithinBounds, clientBounds.Size);
             }
         }
         
@@ -90,10 +90,10 @@ namespace Microsoft.Xna.Platform.Input.Touch
             if (wndHandle != IntPtr.Zero)
             {
                 GameWindow gameWindow = BlazorGameWindow.FromHandle(wndHandle);
-                Rectangle windowsBounds = gameWindow.ClientBounds;
-                Point winSize = new Point(windowsBounds.Width, windowsBounds.Height);
+                Rectangle clientBounds = gameWindow.ClientBounds;
+                Vector2 positionWithinBounds = position - clientBounds.Location.ToVector2();
 
-                base.AddMovedEvent(nativeTouchId, position, winSize);
+                base.AddMovedEvent(nativeTouchId, positionWithinBounds, clientBounds.Size);
             }
         }
 
@@ -103,10 +103,10 @@ namespace Microsoft.Xna.Platform.Input.Touch
             if (wndHandle != IntPtr.Zero)
             {
                 GameWindow gameWindow = BlazorGameWindow.FromHandle(wndHandle);
-                Rectangle windowsBounds = gameWindow.ClientBounds;
-                Point winSize = new Point(windowsBounds.Width, windowsBounds.Height);
+                Rectangle clientBounds = gameWindow.ClientBounds;
+                Vector2 positionWithinBounds = position - clientBounds.Location.ToVector2();
 
-                base.AddReleasedEvent(nativeTouchId, position, winSize);
+                base.AddReleasedEvent(nativeTouchId, positionWithinBounds, clientBounds.Size);
             }
         }
         public override void AddCanceledEvent(int nativeTouchId, Vector2 position)
@@ -115,10 +115,10 @@ namespace Microsoft.Xna.Platform.Input.Touch
             if (wndHandle != IntPtr.Zero)
             {
                 GameWindow gameWindow = BlazorGameWindow.FromHandle(wndHandle);
-                Rectangle windowsBounds = gameWindow.ClientBounds;
-                Point winSize = new Point(windowsBounds.Width, windowsBounds.Height);
+                Rectangle clientBounds = gameWindow.ClientBounds;
+                Vector2 positionWithinBounds = position - clientBounds.Location.ToVector2();
 
-                base.AddReleasedEvent(nativeTouchId, position, winSize);
+                base.AddReleasedEvent(nativeTouchId, positionWithinBounds, clientBounds.Size);
             }
         }
 

--- a/Templates/VisualStudio2022/ProjectTemplates/BlazorGL.NetCore/wwwroot/css/app.css
+++ b/Templates/VisualStudio2022/ProjectTemplates/BlazorGL.NetCore/wwwroot/css/app.css
@@ -76,7 +76,7 @@ a, .btn-link
 
 #theCanvas 
 {
-    position: fixed;
+    position: absolute;
     top: 0px;
     right: 0px;
     bottom: 0px;

--- a/Templates/VisualStudio2022/ProjectTemplates/Multiplatform.NetCore/BlazorGL/wwwroot/css/app.css
+++ b/Templates/VisualStudio2022/ProjectTemplates/Multiplatform.NetCore/BlazorGL/wwwroot/css/app.css
@@ -76,7 +76,7 @@ a, .btn-link
 
 #theCanvas 
 {
-    position: fixed;
+    position: absolute;
     top: 0px;
     right: 0px;
     bottom: 0px;


### PR DESCRIPTION
Currently Kni.BlazorGL only works correctly when the canvas is a full viewport element located at the origin position (using an Iframe also works as internally it acts like the whole viewport). If the `canvasHolder` is reposition/resized to appear elsewhere then the canvas doesn't update correctly. The mouse/touch input positions are also wrong.

The existing `JsWindowOnResize` event cannot be used for partial viewport / non origin element locations either, as the full window size values will not be applicable in these cases.

To resolve these issues, this PR ensures the `BlazorGameWindow.ClientBounds` match the actual `canvasHolder` position and size. This is then used to update `theCanvas` size, call `UpdateBackBufferSize`, and adjust mouse/touch input positions accordingly.

Also the templates currently set both the `canvasHolder` and `theCanvas` to use the css position of `fixed`. However this means `theCanvas` doesn't actually get placed inside the `canvasHolder` and instead acts like it is floating separately from it. By changing `theCanvas` to use a  css position of `absolute`, it instead is placed inside the `canvasHolder` and is repositioned accordingly.

The associated required Wasm changes ("Adds DOMRect and Element.GetBoundingClientRect") are located here:
https://github.com/nkast/Wasm/pull/18
