### PR TITLE
Fixes OcclusionQuery for Android.GL

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteOcclusionQuery.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteOcclusionQuery.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Xna.Platform.Graphics
         
         public override int PixelCount { get { throw new NotImplementedException(); } }
 
+        public override bool AnyPixelsPassed { get { throw new NotImplementedException(); } }
+
         public override bool IsComplete { get { throw new NotImplementedException(); } }
 
         internal ConcreteOcclusionQuery(GraphicsContextStrategy contextStrategy)

--- a/Platforms/Graphics/.DX11/ConcreteOcclusionQuery.cs
+++ b/Platforms/Graphics/.DX11/ConcreteOcclusionQuery.cs
@@ -26,6 +26,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         public override int PixelCount { get { return _pixelCount; } }
 
+        public override bool AnyPixelsPassed { get { return _pixelCount > 0; } }
+
         public override bool IsComplete
         {
             get

--- a/Platforms/Graphics/.GL/ConcreteOcclusionQuery.cs
+++ b/Platforms/Graphics/.GL/ConcreteOcclusionQuery.cs
@@ -35,8 +35,6 @@ namespace Microsoft.Xna.Platform.Graphics
                     return false;
 
                 return PlatformGetResult();
-
-                return _isComplete;
             }
         }
 
@@ -59,7 +57,10 @@ namespace Microsoft.Xna.Platform.Graphics
             _inBeginEndPair = true;
             _isComplete = false;
 
-            GL.BeginQuery(QueryTarget.SamplesPassed, _glQueryId);
+            QueryTarget queryTarget = GraphicsDevice.Adapter.Backend == GraphicsBackend.OpenGL ?
+                QueryTarget.SamplesPassed : QueryTarget.SamplesPassedExt;
+
+            GL.BeginQuery(queryTarget, _glQueryId);
             GL.CheckGLError();
         }
 
@@ -73,7 +74,10 @@ namespace Microsoft.Xna.Platform.Graphics
             _inBeginEndPair = false;
             _queryPerformed = true;
 
-            GL.EndQuery(QueryTarget.SamplesPassed);
+            QueryTarget queryTarget = GraphicsDevice.Adapter.Backend == GraphicsBackend.OpenGL ?
+                QueryTarget.SamplesPassed : QueryTarget.SamplesPassedExt;
+
+            GL.EndQuery(queryTarget);
             GL.CheckGLError();
         }
 

--- a/Platforms/Graphics/.GL/ConcreteOcclusionQuery.cs
+++ b/Platforms/Graphics/.GL/ConcreteOcclusionQuery.cs
@@ -18,11 +18,22 @@ namespace Microsoft.Xna.Platform.Graphics
         private bool _inBeginEndPair;  // true if Begin was called and End was not yet called.
         private bool _queryPerformed;  // true if Begin+End were called at least once.
         private bool _isComplete;      // true if the result is available in _pixelCount.
-        private int _pixelCount;       // The query result.
+        private int _queryResultValue; // The query result.
 
         private int _glQueryId = -1;
 
-        public override int PixelCount { get { return _pixelCount; } }
+        public override int PixelCount
+        {
+            get
+            {
+                if (GraphicsDevice.Adapter.Backend == GraphicsBackend.OpenGL)
+                    return _queryResultValue;
+                else
+                    throw new PlatformNotSupportedException();
+            }
+        }
+
+        public override bool AnyPixelsPassed { get { return _queryResultValue > 0; } }
 
         public override bool IsComplete
         {
@@ -91,12 +102,12 @@ namespace Microsoft.Xna.Platform.Graphics
 
             if (resultReady == 0)
             {
-                _pixelCount = 0;
+                _queryResultValue = 0;
                 _isComplete = false;
             }
             else
             {
-                GL.GetQueryObject(_glQueryId, GetQueryObjectParam.QueryResult, out _pixelCount);
+                GL.GetQueryObject(_glQueryId, GetQueryObjectParam.QueryResult, out _queryResultValue);
                 GL.CheckGLError();
                 _isComplete = true;
             }

--- a/Platforms/Graphics/.Ref/ConcreteOcclusionQuery.cs
+++ b/Platforms/Graphics/.Ref/ConcreteOcclusionQuery.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         public override int PixelCount { get { throw new PlatformNotSupportedException(); } }
 
+        public override bool AnyPixelsPassed { get { throw new PlatformNotSupportedException(); } }
+
         public override bool IsComplete { get { throw new PlatformNotSupportedException(); } }
 
         internal ConcreteOcclusionQuery(GraphicsContextStrategy contextStrategy)

--- a/src/Xna.Framework.Graphics/Graphics/OcclusionQuery.cs
+++ b/src/Xna.Framework.Graphics/Graphics/OcclusionQuery.cs
@@ -31,6 +31,8 @@ namespace Microsoft.Xna.Framework.Graphics
         /// The occlusion query has not yet completed. Check <see cref="IsComplete"/> before reading
         /// the result!
         /// </exception>
+        /// <remarks>For GLES and WebGL, the exact pixel count is not available. 
+        /// Instead, a value of 1 indicates that one or more pixels are visible.</remarks>
         public int PixelCount
         {
             get

--- a/src/Xna.Framework.Graphics/Graphics/OcclusionQuery.cs
+++ b/src/Xna.Framework.Graphics/Graphics/OcclusionQuery.cs
@@ -31,8 +31,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// The occlusion query has not yet completed. Check <see cref="IsComplete"/> before reading
         /// the result!
         /// </exception>
-        /// <remarks>For GLES and WebGL, the exact pixel count is not available. 
-        /// Instead, a value of 1 indicates that one or more pixels are visible.</remarks>
+        /// <remarks>PixelCount is not available on platforms using GLES/WebGL. Use AnyPixelsPassed instead.</remarks>
         public int PixelCount
         {
             get
@@ -41,6 +40,28 @@ namespace Microsoft.Xna.Framework.Graphics
                     throw new InvalidOperationException("The occlusion query has not yet completed. Check IsComplete before reading the result.");
 
                 return _strategy.PixelCount;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating if at least one or more pixels are visible.
+        /// </summary>
+        /// <value>
+        /// <see langword="true"/> if one or more pixels are visible; otherwise,
+        /// <see langword="false"/>.
+        /// </value>
+        /// <exception cref="InvalidOperationException">
+        /// The occlusion query has not yet completed. Check <see cref="IsComplete"/> before reading
+        /// the result!
+        /// </exception>
+        public bool AnyPixelsPassed
+        {
+            get
+            {
+                if (!IsComplete)
+                    throw new InvalidOperationException("The occlusion query has not yet completed. Check IsComplete before reading the result.");
+
+                return _strategy.AnyPixelsPassed;
             }
         }
 

--- a/src/Xna.Framework.Graphics/Graphics/OcclusionQueryStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/OcclusionQueryStrategy.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
 
         public abstract int PixelCount { get; }
+        public abstract bool AnyPixelsPassed { get; }
         public abstract bool IsComplete { get; }
 
         protected OcclusionQueryStrategy(GraphicsContextStrategy contextStrategy)


### PR DESCRIPTION
Fixes OcclusionQuery for Android with GLES.

`QueryTarget.SamplesPassed` is only available for OpenGL, not GLES. However, `QueryTarget.SamplesPassedExt` is supported for GLES, but only returns a result of 0 or 1 (where 1 represents one or more pixels visible) instead of the actual pixel count.

Although labelled as an extension, it is a core feature of GLES 3 and only an extension for GLES 2. Both names use the same enum value.

For GLES 2 (https://registry.khronos.org/OpenGL/extensions/EXT/EXT_occlusion_query_boolean.txt):
>ANY_SAMPLES_PASSED_EXT                         0x8C2F

For GLES 3 (https://registry.khronos.org/OpenGL/api/GLES3/gl3.h):
> #define GL_ANY_SAMPLES_PASSED             0x8C2F

For testing, the XNA Lens Flare sample with Kni projects added can be found here: https://github.com/kniEngine/XNAGameStudio/pull/1