### PR TITLE
Fixes XAudio2 DynamicSoundEffectInstance.Apply3D

### DIFF
--- a/Platforms/Audio/XAudio/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/XAudio/ConcreteSoundEffectInstance.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Xna.Platform.Audio
             Emitter e = ToDXEmitter(emitter);
             e.CurveDistanceScaler = SoundEffect.DistanceScale;
             e.DopplerScaler = SoundEffect.DopplerScale;
-            e.ChannelCount = _concreteSoundEffect._format.Channels;
+            e.ChannelCount = _voice.VoiceDetails.InputChannelCount;
 
             //stereo channel
             if (e.ChannelCount > 1)
@@ -131,7 +131,7 @@ namespace Microsoft.Xna.Platform.Audio
 
             // Number of channels in the sound being played.
             // Not actually sure if XNA supported 3D attenuation of sterio sounds, but X3DAudio does.
-            int srcChannelCount = _concreteSoundEffect._format.Channels;
+            int srcChannelCount = _voice.VoiceDetails.InputChannelCount;
 
             // Number of output channels.
             int dstChannelCount = ConcreteAudioService.MasterVoice.VoiceDetails.InputChannelCount;


### PR DESCRIPTION
Currently `DynamicSoundEffectInstance.Apply3D` uses the `SoundEffectInstance` method implementation, which in turn uses the channel count from `_concreteSoundEffect`. However `_concreteSoundEffect` is not used for `DynamicSoundEffectInstance`.

This fix swaps to using `_voice.VoiceDetails.InputChannelCount` as this is correct for both `SoundEffectInstance` and `DynamicSoundEffectInstance`.

For testing, this project can be used to play and adjust listener/emitter positions (click Apply3D to enable 3D sound calculations): https://github.com/squarebananas/XnaApiTesting