### PR TITLE
Fixes XAudio2 DynamicSoundEffectInstance.Pitch

### DIFF
--- a/Platforms/Audio/XAudio/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/XAudio/ConcreteDynamicSoundEffectInstance.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Xna.Platform.Audio
             _channels = channels;
             WaveFormat format = new WaveFormat(sampleRate, channels);
 
-            _voice = new SourceVoice(ConcreteAudioService.Device, format, true);
+            _voice = new SourceVoice(ConcreteAudioService.Device, format, VoiceFlags.None, XAudio2.MaximumFrequencyRatio, true);
             _voice.BufferEnd += OnBufferEnd;
         }
 


### PR DESCRIPTION
Currently adjusting the pitch of a `DynamicSoundEffectInstance` with XAudio2 only allows the pitch to be reduced and not increased (anything above 0 has no effect).

This is because the `_voice` is created using:
`voice = new SourceVoice(ConcreteAudioService.Device, format, true);`

And within SharpDX.XAudio2 this calls the following (setting the `maxFrequencyRatio` to 1):
```
public SourceVoice(XAudio2 device, WaveFormat sourceFormat, bool enableCallbackEvents)
    : this(device, sourceFormat, VoiceFlags.None, 1f, enableCallbackEvents)
```
```
public SourceVoice(XAudio2 device, WaveFormat sourceFormat, VoiceFlags flags, float maxFrequencyRatio,
    bool enableCallbackEvents)
```

The fix is to use `XAudio2.MaximumFrequencyRatio` instead, which matches the value used when creating a `SoundEffectInstance`.

For testing, this project can be used to play sounds and adjust the pitch: https://github.com/squarebananas/XnaApiTesting