### PR TITLE
Implements SoundEffect formats for Blazor.GL

### DIFF
--- a/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
@@ -146,11 +146,23 @@ namespace Microsoft.Xna.Platform.Audio
             {
                 fixed (void* pBuffer = buffer)
                 {
+                    float[] dest = new float[sampleCount];
                     switch (sampleBits)
                     {
+                        case 8: // PCM 8bit
+                            byte* pBuffer8 = (byte*)pBuffer;
+                            for (int c = 0; c < numOfChannels; c++)
+                            {
+                                for (int i = 0; i < sampleCount; i++)
+                                {
+                                    dest[i] = ((float)pBuffer8[i * numOfChannels + c] - 128f) / 128f;
+                                }
+                                _audioBuffer.CopyToChannel(dest, c);
+                            }
+                            break;
+
                         case 16: // PCM 16bit
                             short* pBuffer16 = (short*)pBuffer;
-                            float[] dest = new float[sampleCount];
                             for (int c = 0; c < numOfChannels; c++)
                             {
                                 for (int i = 0; i < sampleCount; i++)
@@ -158,7 +170,34 @@ namespace Microsoft.Xna.Platform.Audio
                                     dest[i] = (float)pBuffer16[i * numOfChannels + c] / 32768f;
                                 }
                                 _audioBuffer.CopyToChannel(dest, c);
-                            }                           
+                            }
+                            break;
+
+                        case 24: // PCM 24bit
+                            byte* pBufferBytes = (byte*)pBuffer;
+                            for (int c = 0; c < numOfChannels; c++)
+                            {
+                                for (int i = 0; i < sampleCount; i++)
+                                {
+                                    int offset = (i * numOfChannels + c) * 3;
+                                    int sample = (pBufferBytes[offset + 2] << 24) | (pBufferBytes[offset + 1] << 16) | (pBufferBytes[offset] << 8);
+                                    sample >>= 8;
+                                    dest[i] = sample / 8388608f;
+                                }
+                                _audioBuffer.CopyToChannel(dest, c);
+                            }
+                            break;
+
+                        case 32: // PCM 32bit
+                            int* pBuffer32 = (int*)pBuffer;
+                            for (int c = 0; c < numOfChannels; c++)
+                            {
+                                for (int i = 0; i < sampleCount; i++)
+                                {
+                                    dest[i] = (float)pBuffer32[i * numOfChannels + c] / 2147483648f;
+                                }
+                                _audioBuffer.CopyToChannel(dest, c);
+                            }
                             break;
 
                         default:
@@ -200,7 +239,7 @@ namespace Microsoft.Xna.Platform.Audio
                                     dest[i] = pBuffer32f[i * numOfChannels + c];
                                 }
                                 _audioBuffer.CopyToChannel(dest, c);
-                            }                           
+                            }
                             break;
 
                         default:

--- a/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
@@ -155,7 +155,7 @@ namespace Microsoft.Xna.Platform.Audio
                             {
                                 for (int i = 0; i < sampleCount; i++)
                                 {
-                                    dest[i] = (float)pBuffer16[i * numOfChannels] / (float)short.MaxValue;
+                                    dest[i] = (float)pBuffer16[i * numOfChannels + c] / 32768f;
                                 }
                                 _audioBuffer.CopyToChannel(dest, c);
                             }                           
@@ -197,7 +197,7 @@ namespace Microsoft.Xna.Platform.Audio
                             {
                                 for (int i = 0; i < sampleCount; i++)
                                 {
-                                    dest[i] = pBuffer32f[i * numOfChannels];
+                                    dest[i] = pBuffer32f[i * numOfChannels + c];
                                 }
                                 _audioBuffer.CopyToChannel(dest, c);
                             }                           

--- a/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffect.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Xna.Platform.Audio
 
             duration = TimeSpan.FromSeconds((float)sampleCount / (float)freq);
 
-            PlatformInitializeBuffer(buffer, 0, buffer.Length, audioFormat, channels, freq, blockAlignment, bitsPerSample, 0, sampleCount / channels);
+            PlatformInitializeBuffer(buffer, 0, buffer.Length, audioFormat, channels, freq, blockAlignment, bitsPerSample, 0, 0);
         }
 
         private void PlatformInitializeBuffer(byte[] buffer, int bufferOffset, int bufferSize, int audioFormat, int channels, int sampleRate, int blockAlignment, int bitsPerSample, int loopStart, int loopLength)
@@ -137,8 +137,9 @@ namespace Microsoft.Xna.Platform.Audio
                 throw new NotImplementedException();
 
             int numOfChannels = (int)channels;
-            
-            _audioBuffer = concreteAudioService.Context.CreateBuffer(numOfChannels, loopLength, sampleRate);
+            int sampleCount = count / (numOfChannels * sampleBits / 8);
+
+            _audioBuffer = concreteAudioService.Context.CreateBuffer(numOfChannels, sampleCount, sampleRate);
 
             // convert buffer to float (-1,+1) and set data for each channel.
             unsafe
@@ -149,10 +150,10 @@ namespace Microsoft.Xna.Platform.Audio
                     {
                         case 16: // PCM 16bit
                             short* pBuffer16 = (short*)pBuffer;
-                            float[] dest = new float[loopLength];
+                            float[] dest = new float[sampleCount];
                             for (int c = 0; c < numOfChannels; c++)
                             {
-                                for (int i = 0; i < loopLength; i++)
+                                for (int i = 0; i < sampleCount; i++)
                                 {
                                     dest[i] = (float)pBuffer16[i * numOfChannels] / (float)short.MaxValue;
                                 }
@@ -178,8 +179,9 @@ namespace Microsoft.Xna.Platform.Audio
                 throw new NotImplementedException();
 
             int numOfChannels = (int)channels;
-            
-            _audioBuffer = concreteAudioService.Context.CreateBuffer(numOfChannels, loopLength, sampleRate);
+            int sampleCount = count / (numOfChannels * sampleBits / 8);
+
+            _audioBuffer = concreteAudioService.Context.CreateBuffer(numOfChannels, sampleCount, sampleRate);
 
             // set data for each channel.
             unsafe
@@ -190,10 +192,10 @@ namespace Microsoft.Xna.Platform.Audio
                     {
                         case 32:
                             float* pBuffer32f = (float*)pBuffer;
-                            float[] dest = new float[loopLength];
+                            float[] dest = new float[sampleCount];
                             for (int c = 0; c < numOfChannels; c++)
                             {
-                                for (int i = 0; i < loopLength; i++)
+                                for (int i = 0; i < sampleCount; i++)
                                 {
                                     dest[i] = pBuffer32f[i * numOfChannels];
                                 }


### PR DESCRIPTION
Implements:
- PCM 8-bit, 24-bit & 32-bit support.

Fixes:
- The sample count was incorrectly using loop length. This is suppose to be for loop points contained within an audio file (unimplemented), and was also being passed in as `sampleCount / channels` causing stereo sounds to only contain half the duration.
- Stereo sounds contained the left channel twice rather than left/right due to the buffer index value missing the `c` channel index.
- The conversion to float used `short.MaxValue` which is 1 less in magnitude compared to `short.MinValue`. Although unlikely, this potentially could mean that -32768 / 32767 would result in a value less than -1 (outside of the permitted -1 to 1 range).

For testing, this project can be used to play sounds with different channel / bit formats (will be updated to include left only / right only channel sounds): https://github.com/squarebananas/XnaApiTesting