### PR TITLE
Implements SoundEffectInstance Pause/Resume/Stop/Pitch/Apply3D for Blazor.GL

### DIFF
--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -20,10 +20,15 @@ namespace Microsoft.Xna.Platform.Audio
         internal ConcreteAudioService ConcreteAudioService { get { return (ConcreteAudioService)_audioServiceStrategy; } }
 
         AudioBufferSourceNode _bufferSource;
-        bool _ended;
         protected StereoPannerNode _stereoPannerNode;
         protected GainNode _gainNode;
         protected AudioNode _sourceTarget;
+
+        private bool _started;
+        private bool _paused;
+        private bool _ended;
+        private double _offset;
+        private double _lastCurrentTime;
 
         public override bool IsXAct
         {
@@ -114,43 +119,22 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformPause()
         {
-            throw new NotImplementedException();
+            SourceNodeStop(pause: true);
         }
 
         public override void PlatformPlay(bool isLooped)
         {
-            AudioContext context = ConcreteAudioService.Context;
-
-            _bufferSource = context.CreateBufferSource();
-            _bufferSource.Loop = isLooped;
-            _bufferSource.Buffer = _concreteSoundEffect.GetAudioBuffer();
-            _bufferSource.Connect(_sourceTarget);
-
-            // XAct sound effects are not tied to the SoundEffect master volume.
-            float masterVolume = (!this.IsXAct) ? SoundEffect.MasterVolume : 1f;
-            _gainNode.Gain.SetTargetAtTime(base.Volume * masterVolume, 0, 0);
-            _stereoPannerNode.Pan.SetTargetAtTime(base.Pan, 0, 0);
-
-            _bufferSource.OnEnded += _bufferSource_OnEnded;
-            _bufferSource.Start();
+            SourceNodeStart(offset: 0d);
         }
 
         public override void PlatformResume(bool isLooped)
         {
-            throw new NotImplementedException();
+            SourceNodeStart(offset: _offset);
         }
 
         public override void PlatformStop()
         {
-            AudioContext context = ConcreteAudioService.Context;
-
-            _bufferSource.OnEnded -= _bufferSource_OnEnded;
-            _ended = false;
-
-            _bufferSource.Stop();
-            _bufferSource.Disconnect(_sourceTarget);
-            _bufferSource.Dispose();
-            _bufferSource = null;
+            SourceNodeStop(pause: false);
         }
 
         public override void PlatformRelease(bool isLooped)
@@ -159,15 +143,12 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override bool PlatformUpdateState(ref SoundState state)
         {
-            if (state != SoundState.Stopped && _ended)
+            UpdateOffset();
+
+            if (state == SoundState.Playing && _ended)
             {
-                _ended = false;
+                SourceNodeStop(pause: false);
                 state = SoundState.Stopped;
-
-                _bufferSource.Disconnect(_sourceTarget);
-                _bufferSource.Dispose();
-                _bufferSource = null;
-
                 return true;
             }
 
@@ -192,6 +173,74 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformClearFilter()
         {
+        }
+
+        private void SourceNodeStart(double offset)
+        {
+            AudioContext context = ConcreteAudioService.Context;
+            AudioBuffer audioBuffer = _concreteSoundEffect.GetAudioBuffer();
+
+            _bufferSource = context.CreateBufferSource();
+            _bufferSource.Loop = IsLooped;
+            _bufferSource.Buffer = audioBuffer;
+            _bufferSource.OnEnded += _bufferSource_OnEnded;
+            _bufferSource.Connect(_sourceTarget);
+
+            _offset = offset;
+            if (IsLooped)
+                _offset %= audioBuffer.Duration;
+
+            if (_offset == 0)
+                _bufferSource.Start();
+            else
+                _bufferSource.Start(0, _offset);
+
+            _started = true;
+            _paused = false;
+            _lastCurrentTime = context.CurrentTime;
+        }
+
+        private void SourceNodeStop(bool pause)
+        {
+            if (pause)
+                UpdateOffset();
+
+            _bufferSource.OnEnded -= _bufferSource_OnEnded;
+
+            if (!_ended)
+                _bufferSource.Stop();
+
+            _bufferSource.Disconnect(_sourceTarget);
+            _bufferSource.Dispose();
+            _bufferSource = null;
+
+            if (pause)
+            {
+                _paused = true;
+            }
+            else
+            {
+                _started = false;
+                _paused = false;
+            }
+            _ended = false;
+        }
+
+        private void UpdateOffset()
+        {
+            if (!_started || _paused || _ended)
+                return;
+
+            AudioContext context = ConcreteAudioService.Context;
+
+            double currentTime = context.CurrentTime;
+            if (currentTime == _lastCurrentTime)
+                return;
+
+            double elapsedRealTime = currentTime - _lastCurrentTime;
+            double elapsedBufferTime = elapsedRealTime * _bufferSource.PlaybackRate.Value;
+            _offset += elapsedBufferTime;
+            _lastCurrentTime = currentTime;
         }
 
         protected override void Dispose(bool disposing)

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Xna.Platform.Audio
 
         private bool _started;
         private bool _paused;
+        private bool _stopping;
         private bool _ended;
         private double _offset;
         private double _lastCurrentTime;
@@ -139,6 +140,8 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformRelease(bool isLooped)
         {
+            _stopping = true;
+            _bufferSource.Loop = false;
         }
 
         public override bool PlatformUpdateState(ref SoundState state)
@@ -157,7 +160,7 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformSetIsLooped(bool isLooped, SoundState state)
         {
-            if (_bufferSource != null)
+            if (_bufferSource != null && !_stopping)
             {
                 _bufferSource.Loop = isLooped;
             }
@@ -222,6 +225,7 @@ namespace Microsoft.Xna.Platform.Audio
             {
                 _started = false;
                 _paused = false;
+                _stopping = false;
             }
             _ended = false;
         }

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -9,7 +9,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using nkast.Wasm.Audio;
 using AudioListener = Microsoft.Xna.Framework.Audio.AudioListener;
-using WebAudioListener = nkast.Wasm.Audio.AudioListener;
 
 namespace Microsoft.Xna.Platform.Audio
 {
@@ -19,7 +18,8 @@ namespace Microsoft.Xna.Platform.Audio
         private ConcreteSoundEffect _concreteSoundEffect;
         internal ConcreteAudioService ConcreteAudioService { get { return (ConcreteAudioService)_audioServiceStrategy; } }
 
-        AudioBufferSourceNode _bufferSource;
+        private AudioBufferSourceNode _bufferSource;
+        protected PannerNode _pannerNode;
         protected StereoPannerNode _stereoPannerNode;
         protected GainNode _gainNode;
         protected AudioNode _sourceTarget;
@@ -30,6 +30,7 @@ namespace Microsoft.Xna.Platform.Audio
         private bool _ended;
         private double _offset;
         private double _lastCurrentTime;
+        protected float _dopplerEffect;
 
         public override bool IsXAct
         {
@@ -101,6 +102,8 @@ namespace Microsoft.Xna.Platform.Audio
             _stereoPannerNode.Connect(_sourceTarget); _sourceTarget = _stereoPannerNode;
             _gainNode.Connect(_sourceTarget); _sourceTarget = _gainNode;
 
+            _dopplerEffect = 1.0f;
+
             this.Volume = 1.0f;
             this.Pan = 0.0f;
             this.Pitch = 0.0f;
@@ -110,6 +113,42 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformApply3D(AudioListener listener, AudioEmitter emitter)
         {
+            if (_pannerNode == null)
+            {
+                AudioContext context = ConcreteAudioService.Context;
+
+                _stereoPannerNode.Disconnect(context.Destination);
+
+                _pannerNode = context.CreatePanner();
+                _pannerNode.Connect(context.Destination);
+
+                _gainNode.Disconnect(_stereoPannerNode);
+                _gainNode.Connect(_pannerNode);
+
+                _pannerNode.PanningModel = PanningModelType.EqualPower;
+                _pannerNode.DistanceModel = DistanceModelType.Inverse;
+                _pannerNode.RolloffFactor = 1f;
+                _pannerNode.MaxDistance = double.MaxValue;
+            }
+
+            Matrix worldSpaceToListenerSpace = Matrix.Invert(Matrix.CreateWorld(listener.Position, listener.Forward, listener.Up));
+            Vector3 relativePosition = Vector3.Transform(emitter.Position, worldSpaceToListenerSpace);
+
+            _pannerNode.RefDistance = SoundEffect.DistanceScale;
+
+            _pannerNode.PositionX.SetValueAtTime(relativePosition.X, 0f);
+            _pannerNode.PositionY.SetValueAtTime(relativePosition.Y, 0f);
+            _pannerNode.PositionZ.SetValueAtTime(relativePosition.Z, 0f);
+
+            Vector3 direction = (relativePosition != Vector3.Zero) ? Vector3.Normalize(relativePosition) : Vector3.Zero;
+            float listenerRadialVelocity = listener.Velocity.X * direction.X + listener.Velocity.Y * direction.Y + listener.Velocity.Z * direction.Z;
+            float emitterRadialVelocity = emitter.Velocity.X * direction.X + emitter.Velocity.Y * direction.Y + emitter.Velocity.Z * direction.Z;
+
+            float unscaledDopplerEffect = Math.Max((SoundEffect.SpeedOfSound + listenerRadialVelocity), 0.0001f) /
+                Math.Max((SoundEffect.SpeedOfSound + emitterRadialVelocity), 0.0001f);
+            _dopplerEffect = 1f + ((unscaledDopplerEffect - 1f) * SoundEffect.DopplerScale * emitter.DopplerScale);
+
+            SetPlaybackRate();
         }
 
         public override void PlatformPause()
@@ -250,7 +289,7 @@ namespace Microsoft.Xna.Platform.Audio
 
             UpdateOffset();
 
-            float playbackRate = (float)Math.Pow(2, base.Pitch);
+            float playbackRate = (float)Math.Pow(2, base.Pitch) * _dopplerEffect;
             playbackRate = MathHelper.Clamp(playbackRate, 0.5f, 2.0f);
             _bufferSource.PlaybackRate.SetValueAtTime(playbackRate, 0);
         }
@@ -264,11 +303,15 @@ namespace Microsoft.Xna.Platform.Audio
 
                 _gainNode.Dispose();
                 _stereoPannerNode.Dispose();
+
+                if (_pannerNode != null)
+                    _pannerNode.Dispose();
             }
 
             _bufferSource = null;
             _gainNode = null;
             _stereoPannerNode = null;
+            _pannerNode = null;
         }
 
         private void _bufferSource_OnEnded(object sender, EventArgs e)

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -80,13 +80,7 @@ namespace Microsoft.Xna.Platform.Audio
             set
             {
                 base.Pitch = value;
-
-                if (_bufferSource != null)
-                {
-                    float wapitch = (float)Math.Pow(2, value);
-                    //TODO: implement Pitch
-                    //_bufferSource.PlaybackRate.SetTargetAtTime(wapitch, 0, 0.05f);
-                }
+                SetPlaybackRate();
             }
         }
 
@@ -193,6 +187,8 @@ namespace Microsoft.Xna.Platform.Audio
             if (IsLooped)
                 _offset %= audioBuffer.Duration;
 
+            SetPlaybackRate();
+
             if (_offset == 0)
                 _bufferSource.Start();
             else
@@ -245,6 +241,18 @@ namespace Microsoft.Xna.Platform.Audio
             double elapsedBufferTime = elapsedRealTime * _bufferSource.PlaybackRate.Value;
             _offset += elapsedBufferTime;
             _lastCurrentTime = currentTime;
+        }
+
+        protected virtual void SetPlaybackRate()
+        {
+            if (_bufferSource == null)
+                return;
+
+            UpdateOffset();
+
+            float playbackRate = (float)Math.Pow(2, base.Pitch);
+            playbackRate = MathHelper.Clamp(playbackRate, 0.5f, 2.0f);
+            _bufferSource.PlaybackRate.SetValueAtTime(playbackRate, 0);
         }
 
         protected override void Dispose(bool disposing)


### PR DESCRIPTION
Implements some of the remaining functionality for `SoundEffectInstance` on the Blazor.GL platform.

Some additional notes:

- With WebAudio there is no pause/resume functionality on a per sound effect basis. Therefore it is necessary to keep track of the playback position, and on resume start a new sound at the stored playback position.

- As the audio may be running on a different thread within the browser to the main UI thread for the game, the `AudioContext.CurrentTime` is used to accurately accumulate elapsed buffer time. 

- The playback position needs to take into effect the pitch setting as this changes the playback rate. Prior to changing the pitch value, the playback position needs updating according to the `AudioContext.CurrentTime` so that any samples played at the last pitch setting are accumulated properly.

- Stop non-immediate (release) allows pause/resume like XNA, and ensures looping doesn't restart on resume.

With regards to `Apply3D`:

- With WebAudio there is only one `AudioListener` for the `AudioContext`. However with Kni, the listener can be set on a per sound effect basis (for example with split screen games). Therefore it is necessary to transform positions into listener space (much like with OpenAL).

- The `PannerNode` provides panning and distance attenuation, but not the doppler effect. It will automatically merge stereo sounds into mono to correctly pan/gain adjust when in `EqualPower` mode and when disconnected from the `StereoPannerNode`. With XNA attempting to pan would result in a "Pan cannot be set on a 3D sound" error in any case (although I haven't implemented that error).

- By setting `PannerNode.RefDistance` to `SoundEffect.DistanceScale` and setting the `DistanceModel`/`RolloffFactor`/`MaxDistance` values, the gain is reduced by -6 dB every time the listener/emitter distance doubles, which matches XNA behavior.

- The doppler effect is manually calculated and applied to the pitch. In addition to `SoundEffect.DopplerScale`, the `AudioEmitter.DopplerScale` and `SoundEffect.SpeedOfSound` are also implemented (these will need implementing for other platforms too).

- The emitter/listener radial velocities are clamped to just above zero (at an arbitrary value of 0.0001f). This is necessary to prevent unexpected pitch changes from sign reversal. Of course in real world physics, it's possible to go fast enough that a sound will be perceived as playing backwards, but implementing that in an audio framework seems excessive. 

- The emitter direction vectors are not used as non-XACT sounds are omni-directional. With XNA these only effect XACT cues with orientation settings, which this PR doesn't implement any functionality for.

- Multiple listeners are not implemented. Kni currently applies each listener in turn at the framework level (not platform). However this just results in the last listener overriding the internal gain/pan/pitch values applied by the rest.

This PR is dependent on the following nkast.Wasm PRs:
- Implement WebAudio methods for timing <https://github.com/nkast/Wasm/pull/22>
- Adds WebAudio PannerNode <https://github.com/nkast/Wasm/pull/23>

For testing, this project can be used to play/pause/resume/stop sounds and adjust listener/emitter positions (click Apply3D to enable 3D sound calculations): https://github.com/squarebananas/XnaApiTesting