### PR TITLE
Implements DynamicSoundEffectInstance Pause/Resume/Pitch/SampleRate/Channels for Blazor.GL

### DIFF
--- a/Platforms/Audio/Blazor/ConcreteAudioService.cs
+++ b/Platforms/Audio/Blazor/ConcreteAudioService.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Xna.Platform.Audio
     {
         internal AudioContext Context { get; private set; }
 
+        internal bool IsDynamicSoundModuleInitialized { get; set; }
 
         internal ConcreteAudioService()
         {

--- a/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using nkast.Wasm.Audio;
 using nkast.Wasm.ChannelMessaging;
@@ -25,7 +26,10 @@ namespace Microsoft.Xna.Platform.Audio
             BufferProcessed = 1,
             ClearBuffers = 2,
             Pause = 3,
-            Resume = 4
+            Resume = 4,
+            Pitch = 5,
+            SampleRate = 6,
+            Channels = 7
         }
 
         private readonly WeakReference _dynamicSoundEffectInstanceRef = new WeakReference(null);
@@ -40,10 +44,8 @@ namespace Microsoft.Xna.Platform.Audio
             get { return base.Pitch; }
             set
             {
-                if (value != 0)
-                    throw new NotSupportedException("DynamicSoundEffectInstance does not support Pitch.");
-
                 base.Pitch = value;
+                SetPlaybackRate();
             }
         }
 
@@ -52,15 +54,6 @@ namespace Microsoft.Xna.Platform.Audio
         {
             _sampleRate = sampleRate;
             _channels = channels;
-
-            AudioContext context = ConcreteAudioService.Context;
-
-            // TODO: implement resampling.
-            if (_sampleRate != context.SampleRate)
-                throw new NotImplementedException($"Sample rate {_sampleRate} does not match AudioContext sample rate {context.SampleRate}.");
-            // TODO: implement Stereo.
-            if (_channels != 1)
-                throw new NotImplementedException($"Channels {_channels} is not implemented.");
         }
 
         public int BuffersNeeded { get; set; }
@@ -95,12 +88,27 @@ namespace Microsoft.Xna.Platform.Audio
 
             if (!ConcreteAudioService.IsDynamicSoundModuleInitialized)
             {
-            await context.AudioWorklet.AddModuleAsync("js/streamProcessor.js");
+                await context.AudioWorklet.AddModuleAsync("js/streamProcessor.js");
                 ConcreteAudioService.IsDynamicSoundModuleInitialized = true;
             }
 
+            AudioWorkletNodeOptions options = new AudioWorkletNodeOptions()
+            {
+                NumberOfInputs = 0,
+                NumberOfOutputs = 1,
+                OutputChannelCount = new int[] { _channels }
+            };
+
+            _streamSource = context.CreateWorklet("stream-processor", options);
             _streamSource.Port.Message += StreamSource_OnMessage;
             _streamSource.Connect(_sourceTarget);
+
+            _streamSource.Port.PostMessage((int)PortMessageType.SampleRate);
+            _streamSource.Port.PostMessage(_sampleRate);
+            _streamSource.Port.PostMessage((int)PortMessageType.Channels);
+            _streamSource.Port.PostMessage(_channels);
+
+            SetPlaybackRate();
 
             _isStreamSourceInitialized = true;
 
@@ -142,7 +150,7 @@ namespace Microsoft.Xna.Platform.Audio
                 _streamSource.Disconnect(_sourceTarget);
                 _streamSource.Dispose();
                 _streamSource = null;
-        }
+            }
             _isStreamSourceInitialized = false;
             _pendingBuffers = 0;
             _tmpBuffers.Clear();
@@ -186,6 +194,17 @@ namespace Microsoft.Xna.Platform.Audio
                 _streamSource.Port.PostMessage((int)PortMessageType.ClearBuffers);
         }
 
+        protected override void SetPlaybackRate()
+        {
+            if (_streamSource == null)
+                return;
+
+            float playbackRate = (float)Math.Pow(2, base.Pitch) * _dopplerEffect;
+            playbackRate = MathHelper.Clamp(playbackRate, 0.5f, 2.0f);
+
+            _streamSource.Port.PostMessage((int)PortMessageType.Pitch);
+            _streamSource.Port.PostMessage(playbackRate);
+        }
 
         protected override void Dispose(bool disposing)
         {

--- a/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
@@ -82,8 +82,12 @@ namespace Microsoft.Xna.Platform.Audio
         {
             AudioContext context = ConcreteAudioService.Context;
 
+            if (!ConcreteAudioService.IsDynamicSoundModuleInitialized)
+            {
             await context.AudioWorklet.AddModuleAsync("js/streamProcessor.js");
-            _streamSource = context.CreateWorklet("stream-processor");
+                ConcreteAudioService.IsDynamicSoundModuleInitialized = true;
+            }
+
             _streamSource.Port.Message += StreamSource_OnMessage;
             _streamSource.Connect(_sourceTarget);
 

--- a/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteDynamicSoundEffectInstance.cs
@@ -19,6 +19,14 @@ namespace Microsoft.Xna.Platform.Audio
         private bool _isStreamSourceInitialized;
         private int _pendingBuffers;
 
+        private enum PortMessageType
+        {
+            None = 0,
+            BufferProcessed = 1,
+            ClearBuffers = 2,
+            Pause = 3,
+            Resume = 4
+        }
 
         private readonly WeakReference _dynamicSoundEffectInstanceRef = new WeakReference(null);
         DynamicSoundEffectInstance IDynamicSoundEffectInstanceStrategy.DynamicSoundEffectInstance
@@ -64,7 +72,7 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformPause()
         {
-            throw new NotImplementedException();
+            _streamSource.Port.PostMessage((int)PortMessageType.Pause);
         }
 
         public override void PlatformPlay(bool isLooped)
@@ -81,6 +89,9 @@ namespace Microsoft.Xna.Platform.Audio
         private async Task InitStreamSourceAsync()
         {
             AudioContext context = ConcreteAudioService.Context;
+
+            if (context.State == ContextState.Suspended)
+                await context.ResumeAsync();
 
             if (!ConcreteAudioService.IsDynamicSoundModuleInitialized)
             {
@@ -102,21 +113,6 @@ namespace Microsoft.Xna.Platform.Audio
             }
         }
 
-        private void ReleaseMicrophoneDevice()
-        {
-            if (_streamSource != null)
-            {
-                _streamSource.Disconnect(_sourceTarget);
-                _streamSource.Dispose();
-                _streamSource = null;
-            }
-            _isStreamSourceInitialized = false;
-            _pendingBuffers = 0;
-            _tmpBuffers.Clear();
-
-
-        }
-
         private void StreamSource_OnMessage(object sender, MessageEventArgs e)
         {
             if (e.DataByteArray != null)
@@ -127,7 +123,7 @@ namespace Microsoft.Xna.Platform.Audio
             {
                 var msg = e.DataFloat64;
                 
-                if (msg == 1) // buffer is proccessed
+                if (msg == (int)PortMessageType.BufferProcessed)
                 {
                     _pendingBuffers--;
                 }
@@ -136,12 +132,20 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformResume(bool isLooped)
         {
-            throw new NotImplementedException();
+            _streamSource.Port.PostMessage((int)PortMessageType.Resume);
         }
 
         public override void PlatformStop()
         {
-            ReleaseMicrophoneDevice();
+            if (_streamSource != null)
+            {
+                _streamSource.Disconnect(_sourceTarget);
+                _streamSource.Dispose();
+                _streamSource = null;
+        }
+            _isStreamSourceInitialized = false;
+            _pendingBuffers = 0;
+            _tmpBuffers.Clear();
         }
 
         public override void PlatformRelease(bool isLooped)
@@ -177,7 +181,9 @@ namespace Microsoft.Xna.Platform.Audio
         {
             _pendingBuffers = 0;
             _tmpBuffers.Clear();
-            _streamSource.Port.PostMessage(2); // 2 = clear buffers
+
+            if (_streamSource != null)
+                _streamSource.Port.PostMessage((int)PortMessageType.ClearBuffers);
         }
 
 

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -20,10 +20,15 @@ namespace Microsoft.Xna.Platform.Audio
         internal ConcreteAudioService ConcreteAudioService { get { return (ConcreteAudioService)_audioServiceStrategy; } }
 
         AudioBufferSourceNode _bufferSource;
-        bool _ended;
         protected StereoPannerNode _stereoPannerNode;
         protected GainNode _gainNode;
         protected AudioNode _sourceTarget;
+
+        private bool _started;
+        private bool _paused;
+        private bool _ended;
+        private double _offset;
+        private double _lastCurrentTime;
 
         public override bool IsXAct
         {
@@ -114,43 +119,22 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformPause()
         {
-            throw new NotImplementedException();
+            SourceNodeStop(pause: true);
         }
 
         public override void PlatformPlay(bool isLooped)
         {
-            AudioContext context = ConcreteAudioService.Context;
-
-            _bufferSource = context.CreateBufferSource();
-            _bufferSource.Loop = isLooped;
-            _bufferSource.Buffer = _concreteSoundEffect.GetAudioBuffer();
-            _bufferSource.Connect(_sourceTarget);
-
-            // XAct sound effects are not tied to the SoundEffect master volume.
-            float masterVolume = (!this.IsXAct) ? SoundEffect.MasterVolume : 1f;
-            _gainNode.Gain.SetTargetAtTime(base.Volume * masterVolume, 0, 0);
-            _stereoPannerNode.Pan.SetTargetAtTime(base.Pan, 0, 0);
-
-            _bufferSource.OnEnded += _bufferSource_OnEnded;
-            _bufferSource.Start();
+            SourceNodeStart(offset: 0d);
         }
 
         public override void PlatformResume(bool isLooped)
         {
-            throw new NotImplementedException();
+            SourceNodeStart(offset: _offset);
         }
 
         public override void PlatformStop()
         {
-            AudioContext context = ConcreteAudioService.Context;
-
-            _bufferSource.OnEnded -= _bufferSource_OnEnded;
-            _ended = false;
-
-            _bufferSource.Stop();
-            _bufferSource.Disconnect(_sourceTarget);
-            _bufferSource.Dispose();
-            _bufferSource = null;
+            SourceNodeStop(pause: false);
         }
 
         public override void PlatformRelease(bool isLooped)
@@ -159,15 +143,12 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override bool PlatformUpdateState(ref SoundState state)
         {
-            if (state != SoundState.Stopped && _ended)
+            UpdateOffset();
+
+            if (state == SoundState.Playing && _ended)
             {
-                _ended = false;
+                SourceNodeStop(pause: false);
                 state = SoundState.Stopped;
-
-                _bufferSource.Disconnect(_sourceTarget);
-                _bufferSource.Dispose();
-                _bufferSource = null;
-
                 return true;
             }
 
@@ -192,6 +173,74 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformClearFilter()
         {
+        }
+
+        private void SourceNodeStart(double offset)
+        {
+            AudioContext context = ConcreteAudioService.Context;
+            AudioBuffer audioBuffer = _concreteSoundEffect.GetAudioBuffer();
+
+            _bufferSource = context.CreateBufferSource();
+            _bufferSource.Loop = IsLooped;
+            _bufferSource.Buffer = audioBuffer;
+            _bufferSource.OnEnded += _bufferSource_OnEnded;
+            _bufferSource.Connect(_sourceTarget);
+
+            _offset = offset;
+            if (IsLooped)
+                _offset %= audioBuffer.Duration;
+
+            if (_offset == 0)
+                _bufferSource.Start();
+            else
+                _bufferSource.Start(0, _offset);
+
+            _started = true;
+            _paused = false;
+            _lastCurrentTime = context.CurrentTime;
+        }
+
+        private void SourceNodeStop(bool pause)
+        {
+            if (pause)
+                UpdateOffset();
+
+            _bufferSource.OnEnded -= _bufferSource_OnEnded;
+
+            if (!_ended)
+                _bufferSource.Stop();
+
+            _bufferSource.Disconnect(_sourceTarget);
+            _bufferSource.Dispose();
+            _bufferSource = null;
+
+            if (pause)
+            {
+                _paused = true;
+            }
+            else
+            {
+                _started = false;
+                _paused = false;
+            }
+            _ended = false;
+        }
+
+        private void UpdateOffset()
+        {
+            if (!_started || _paused || _ended)
+                return;
+
+            AudioContext context = ConcreteAudioService.Context;
+
+            double currentTime = context.CurrentTime;
+            if (currentTime == _lastCurrentTime)
+                return;
+
+            double elapsedRealTime = currentTime - _lastCurrentTime;
+            double elapsedBufferTime = elapsedRealTime * _bufferSource.PlaybackRate.Value;
+            _offset += elapsedBufferTime;
+            _lastCurrentTime = currentTime;
         }
 
         protected override void Dispose(bool disposing)

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Xna.Platform.Audio
 
         private bool _started;
         private bool _paused;
+        private bool _stopping;
         private bool _ended;
         private double _offset;
         private double _lastCurrentTime;
@@ -139,6 +140,8 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformRelease(bool isLooped)
         {
+            _stopping = true;
+            _bufferSource.Loop = false;
         }
 
         public override bool PlatformUpdateState(ref SoundState state)
@@ -157,7 +160,7 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformSetIsLooped(bool isLooped, SoundState state)
         {
-            if (_bufferSource != null)
+            if (_bufferSource != null && !_stopping)
             {
                 _bufferSource.Loop = isLooped;
             }
@@ -222,6 +225,7 @@ namespace Microsoft.Xna.Platform.Audio
             {
                 _started = false;
                 _paused = false;
+                _stopping = false;
             }
             _ended = false;
         }

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -9,7 +9,6 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using nkast.Wasm.Audio;
 using AudioListener = Microsoft.Xna.Framework.Audio.AudioListener;
-using WebAudioListener = nkast.Wasm.Audio.AudioListener;
 
 namespace Microsoft.Xna.Platform.Audio
 {
@@ -19,7 +18,8 @@ namespace Microsoft.Xna.Platform.Audio
         private ConcreteSoundEffect _concreteSoundEffect;
         internal ConcreteAudioService ConcreteAudioService { get { return (ConcreteAudioService)_audioServiceStrategy; } }
 
-        AudioBufferSourceNode _bufferSource;
+        private AudioBufferSourceNode _bufferSource;
+        protected PannerNode _pannerNode;
         protected StereoPannerNode _stereoPannerNode;
         protected GainNode _gainNode;
         protected AudioNode _sourceTarget;
@@ -30,6 +30,7 @@ namespace Microsoft.Xna.Platform.Audio
         private bool _ended;
         private double _offset;
         private double _lastCurrentTime;
+        protected float _dopplerEffect;
 
         public override bool IsXAct
         {
@@ -101,6 +102,8 @@ namespace Microsoft.Xna.Platform.Audio
             _stereoPannerNode.Connect(_sourceTarget); _sourceTarget = _stereoPannerNode;
             _gainNode.Connect(_sourceTarget); _sourceTarget = _gainNode;
 
+            _dopplerEffect = 1.0f;
+
             this.Volume = 1.0f;
             this.Pan = 0.0f;
             this.Pitch = 0.0f;
@@ -110,6 +113,42 @@ namespace Microsoft.Xna.Platform.Audio
 
         public override void PlatformApply3D(AudioListener listener, AudioEmitter emitter)
         {
+            if (_pannerNode == null)
+            {
+                AudioContext context = ConcreteAudioService.Context;
+
+                _stereoPannerNode.Disconnect(context.Destination);
+
+                _pannerNode = context.CreatePanner();
+                _pannerNode.Connect(context.Destination);
+
+                _gainNode.Disconnect(_stereoPannerNode);
+                _gainNode.Connect(_pannerNode);
+
+                _pannerNode.PanningModel = PanningModelType.EqualPower;
+                _pannerNode.DistanceModel = DistanceModelType.Inverse;
+                _pannerNode.RolloffFactor = 1f;
+                _pannerNode.MaxDistance = double.MaxValue;
+            }
+
+            Matrix worldSpaceToListenerSpace = Matrix.Invert(Matrix.CreateWorld(listener.Position, listener.Forward, listener.Up));
+            Vector3 relativePosition = Vector3.Transform(emitter.Position, worldSpaceToListenerSpace);
+
+            _pannerNode.RefDistance = SoundEffect.DistanceScale;
+
+            _pannerNode.PositionX.SetValueAtTime(relativePosition.X, 0f);
+            _pannerNode.PositionY.SetValueAtTime(relativePosition.Y, 0f);
+            _pannerNode.PositionZ.SetValueAtTime(relativePosition.Z, 0f);
+
+            Vector3 direction = (relativePosition != Vector3.Zero) ? Vector3.Normalize(relativePosition) : Vector3.Zero;
+            float listenerRadialVelocity = listener.Velocity.X * direction.X + listener.Velocity.Y * direction.Y + listener.Velocity.Z * direction.Z;
+            float emitterRadialVelocity = emitter.Velocity.X * direction.X + emitter.Velocity.Y * direction.Y + emitter.Velocity.Z * direction.Z;
+
+            float unscaledDopplerEffect = Math.Max((SoundEffect.SpeedOfSound + listenerRadialVelocity), 0.0001f) /
+                Math.Max((SoundEffect.SpeedOfSound + emitterRadialVelocity), 0.0001f);
+            _dopplerEffect = 1f + ((unscaledDopplerEffect - 1f) * SoundEffect.DopplerScale * emitter.DopplerScale);
+
+            SetPlaybackRate();
         }
 
         public override void PlatformPause()
@@ -250,7 +289,7 @@ namespace Microsoft.Xna.Platform.Audio
 
             UpdateOffset();
 
-            float playbackRate = (float)Math.Pow(2, base.Pitch);
+            float playbackRate = (float)Math.Pow(2, base.Pitch) * _dopplerEffect;
             playbackRate = MathHelper.Clamp(playbackRate, 0.5f, 2.0f);
             _bufferSource.PlaybackRate.SetValueAtTime(playbackRate, 0);
         }
@@ -264,11 +303,15 @@ namespace Microsoft.Xna.Platform.Audio
 
                 _gainNode.Dispose();
                 _stereoPannerNode.Dispose();
+
+                if (_pannerNode != null)
+                    _pannerNode.Dispose();
             }
 
             _bufferSource = null;
             _gainNode = null;
             _stereoPannerNode = null;
+            _pannerNode = null;
         }
 
         private void _bufferSource_OnEnded(object sender, EventArgs e)

--- a/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
+++ b/Platforms/Audio/Blazor/ConcreteSoundEffectInstance.cs
@@ -80,13 +80,7 @@ namespace Microsoft.Xna.Platform.Audio
             set
             {
                 base.Pitch = value;
-
-                if (_bufferSource != null)
-                {
-                    float wapitch = (float)Math.Pow(2, value);
-                    //TODO: implement Pitch
-                    //_bufferSource.PlaybackRate.SetTargetAtTime(wapitch, 0, 0.05f);
-                }
+                SetPlaybackRate();
             }
         }
 
@@ -193,6 +187,8 @@ namespace Microsoft.Xna.Platform.Audio
             if (IsLooped)
                 _offset %= audioBuffer.Duration;
 
+            SetPlaybackRate();
+
             if (_offset == 0)
                 _bufferSource.Start();
             else
@@ -245,6 +241,18 @@ namespace Microsoft.Xna.Platform.Audio
             double elapsedBufferTime = elapsedRealTime * _bufferSource.PlaybackRate.Value;
             _offset += elapsedBufferTime;
             _lastCurrentTime = currentTime;
+        }
+
+        protected virtual void SetPlaybackRate()
+        {
+            if (_bufferSource == null)
+                return;
+
+            UpdateOffset();
+
+            float playbackRate = (float)Math.Pow(2, base.Pitch);
+            playbackRate = MathHelper.Clamp(playbackRate, 0.5f, 2.0f);
+            _bufferSource.PlaybackRate.SetValueAtTime(playbackRate, 0);
         }
 
         protected override void Dispose(bool disposing)

--- a/Templates/dotnetTemplates/content/BlazorGL.NetCore.CSharp/wwwroot/js/streamProcessor.js
+++ b/Templates/dotnetTemplates/content/BlazorGL.NetCore.CSharp/wwwroot/js/streamProcessor.js
@@ -5,6 +5,7 @@ class StreamProcessor extends AudioWorkletProcessor
     {
         super();
         this.queue = [];
+        this.paused = false;
 
         this.port.onmessage = (event) =>
         {
@@ -12,9 +13,14 @@ class StreamProcessor extends AudioWorkletProcessor
 
             if (typeof data === 'number')
             {
-                if (data === 2)
-                {                    
-                    this.queue = [];
+                switch (data)
+                {
+                    case 2:
+                        this.queue = []; break;
+                    case 3:
+                        this.paused = true; break;
+                    case 4:
+                        this.paused = false; break;
                 }
             }
             if (data instanceof Uint8Array)
@@ -36,7 +42,7 @@ class StreamProcessor extends AudioWorkletProcessor
 
         let written = 0;
 
-        while (written < sampleCount && this.queue.length > 0)
+        while (written < sampleCount && this.queue.length > 0 && !this.paused)
         {
             const buffer = this.queue[0];
             const offset = buffer.offset;

--- a/Templates/dotnetTemplates/content/BlazorGL.NetCore.CSharp/wwwroot/js/streamProcessor.js
+++ b/Templates/dotnetTemplates/content/BlazorGL.NetCore.CSharp/wwwroot/js/streamProcessor.js
@@ -5,7 +5,12 @@ class StreamProcessor extends AudioWorkletProcessor
     {
         super();
         this.queue = [];
+        this.samplePosition = 0;
         this.paused = false;
+        this.pitchPlaybackRate = 1;
+        this.formatSampleRate = 44100;
+        this.formatChannels = 1;
+        this.receivingValueForMessageType = -1;
 
         this.port.onmessage = (event) =>
         {
@@ -13,20 +18,40 @@ class StreamProcessor extends AudioWorkletProcessor
 
             if (typeof data === 'number')
             {
-                switch (data)
+                if (this.receivingValueForMessageType === -1)
                 {
-                    case 2:
-                        this.queue = []; break;
-                    case 3:
-                        this.paused = true; break;
-                    case 4:
-                        this.paused = false; break;
+                    switch (data)
+                    {
+                        case 2:
+                            this.queue = []; break;
+                        case 3:
+                            this.paused = true; break;
+                        case 4:
+                            this.paused = false; break;
+                        case 5:
+                        case 6:
+                        case 7:
+                            this.receivingValueForMessageType = data;
+                            break;
+                    }
+                }
+                else
+                {
+                    switch (this.receivingValueForMessageType)
+                    {
+                        case 5:
+                            this.pitchPlaybackRate = data; break;
+                        case 6:
+                            this.formatSampleRate = data; break;
+                        case 7:
+                            this.formatChannels = data; break;
+                    }
+                    this.receivingValueForMessageType = -1;
                 }
             }
             if (data instanceof Uint8Array)
             {
                 const buffer = new Int16Array(data.buffer, data.byteOffset, data.length / 2);
-                buffer.offset = 0;
                 this.queue.push(buffer);
             }
         };
@@ -35,53 +60,61 @@ class StreamProcessor extends AudioWorkletProcessor
 
     process(inputs, outputs, parameters)
     {
+        const inputChannelCount = this.formatChannels;
+        const formatPlaybackRate = this.formatSampleRate / sampleRate;
+        const playbackRate = formatPlaybackRate * this.pitchPlaybackRate;
+
         const output = outputs[0];
-        
-        const channelCount = output.length;
-        const sampleCount = output[0].length;
+        const outputChannelCount = output.length;
+        const outputSampleCount = output[0].length;
 
         let written = 0;
 
-        while (written < sampleCount && this.queue.length > 0 && !this.paused)
+        while (written < outputSampleCount && this.queue.length > 0 && !this.paused)
         {
             const buffer = this.queue[0];
-            const offset = buffer.offset;
+            const samplesInBuffer = buffer.length / inputChannelCount;
+            let nextSamplePosition = this.samplePosition;
 
-            const available = buffer.length - offset;
-            const needed = sampleCount - written;
-            const copyCount = Math.min(available, needed);
-
-            for (let i = 0; i < copyCount; i++)
+            while (written < outputSampleCount && nextSamplePosition < samplesInBuffer)
             {
-                for (let c = 0; c < channelCount; c++)
+                let offset = Math.floor(nextSamplePosition) * inputChannelCount;
+                for (let outputChannel = 0; outputChannel < outputChannelCount; outputChannel++)
                 {
-                    const channel = output[c];
-                    let value = (buffer[offset+i] / 32767);
-                    channel[written+i] = value;
+                    let inputChannel = outputChannel % inputChannelCount;
+                    let value1 = buffer[offset + inputChannel];
+                    let value2;
+                    if (nextSamplePosition < samplesInBuffer - 1)
+                        value2 = buffer[offset + inputChannelCount + inputChannel];
+                    else if (this.queue.length > 1)
+                        value2 = this.queue[1][inputChannel];
+                    else
+                        value2 = value1;
+                    let value = (value1 + ((value2 - value1) * (nextSamplePosition % 1))) / 32768;
+                    output[outputChannel][written] = value;
                 }
+                written++;
+                nextSamplePosition += playbackRate;
             }
-            
-            written += copyCount;
-            buffer.offset += copyCount;
 
-            if (buffer.offset >= buffer.length)
+            if (nextSamplePosition >= samplesInBuffer)
             {
+                nextSamplePosition -= samplesInBuffer;
                 this.queue.shift();
                 this.port.postMessage(1);
             }
+
+            this.samplePosition = nextSamplePosition;
         }
         
         // Fill remaining samples with silence
-        if (written < sampleCount)
+        if (written < outputSampleCount)
         {
-            for (let c = 0; c < channelCount; c++)
+            for (let outputChannel = 0; outputChannel < outputChannelCount; outputChannel++)
             {
-                const channel = output[c];
-
-                for (let i = written; i < sampleCount; i++)
+                for (let i = written; i < outputSampleCount; i++)
                 {
-                    let value = 0;
-                    channel[i] = value;
+                    output[outputChannel][i] = 0;
                 }
             }
         }


### PR DESCRIPTION
Implements some of the remaining functionality for `DynamicSoundEffectInstance` on the Blazor.GL platform.

Some additional notes:

- `AudioWorklet.AddModuleAsync` is only needed per `AudioContext`, not per sound instance. Therefore `AudioContext.IsDynamicSoundModuleInitialized` has been added so that it is only loaded once. (This may need looking at for the microphone implementation too).

- Whereas playing a `SoundEffectInstance` will transition the `AudioContext` to a running state, playing a `DynamicSoundEffectInstance` sometimes doesn't and remains as suspended. Running `ResumeAsync` prior to playing appears to fix this.
 
- `AudioWorkletNodeOptions` is used with `CreateWorklet` to configure the number of channels contained within the js side output variable. This allows stereo playback.

- Pause/resume is achieved by filling the output buffer with zeros (unlike `SoundEffectInstance` which starts a new sound). As each call for the worklet process function only contains a few milliseconds of samples, this should be called at a faster rate than the game tick, making it responsive. 

- Linear interpolation is used for sampling between buffer samples. While this could be improved (with a performance cost), this method seems in line with other audio engine implementations (such as FAudio's method to replicate XAudio2 behavior and Chromium's internal WebAudio implementation).

- Interpolation occurs between buffers if a sub-sample is needed between the last sample of the current buffer and the first sample of the next buffer.

- The `Apply3D` implementation is derived from `SoundEffectInstance`, so no additional code is needed for this. 

This PR is dependent on the following PRs:

- Implements SoundEffectInstance Pause/Resume/Stop/Pitch/Apply3D for Blazor.GL https://github.com/kniEngine/kni/pull/2614
- Implement WebAudio methods for timing https://github.com/nkast/Wasm/pull/22
- Adds WebAudio PannerNode https://github.com/nkast/Wasm/pull/23
- Adds WebAudio AudioWorkletNodeOptions https://github.com/nkast/Wasm/pull/24

For testing, this project can be used to play/pause/resume/stop sounds and adjust listener/emitter positions (click Apply3D to enable 3D sound calculations): https://github.com/squarebananas/XnaApiTesting