### PR TITLE
Implements Mouse xButton1/2 for Blazor.GL

### DIFF
--- a/Platforms/Input/.Blazor/ConcreteMouse.cs
+++ b/Platforms/Input/.Blazor/ConcreteMouse.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Xna.Platform.Input
         private Point _pos;
         private int _scrollX, _scrollY;
         private int _rawX, _rawY;
-        private ButtonState _leftButton, _rightButton, _middleButton;
+        private ButtonState _leftButton, _rightButton, _middleButton, _xButton1, _xButton2;
 
 
         public override IntPtr PlatformGetWindowHandle()
@@ -35,6 +35,8 @@ namespace Microsoft.Xna.Platform.Input
                 _leftButton = default(ButtonState);
                 _rightButton = default(ButtonState);
                 _middleButton = default(ButtonState);
+                _xButton1 = default(ButtonState);
+                _xButton2 = default(ButtonState);
 
                 _domWindow.OnMouseMove -= OnMouseMove;
                 _domWindow.OnMouseDown -= OnMouseDown;
@@ -65,8 +67,8 @@ namespace Microsoft.Xna.Platform.Input
                     leftButton: _leftButton,
                     middleButton: _middleButton,
                     rightButton: _rightButton,
-                    xButton1: ButtonState.Released,
-                    xButton2: ButtonState.Released
+                    xButton1: _xButton1,
+                    xButton2: _xButton2
                     );
 
             return mouseState;
@@ -94,18 +96,22 @@ namespace Microsoft.Xna.Platform.Input
         {
             _pos.X = x;
             _pos.Y = y;
-            _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _leftButton   = ((buttons &  1) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _rightButton  = ((buttons &  2) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _middleButton = ((buttons &  4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _xButton1     = ((buttons &  8) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _xButton2     = ((buttons & 16) != 0) ? ButtonState.Pressed : ButtonState.Released;
         }
 
         private void OnMouseUp(object sender, int x, int y, int buttons)
         {
             _pos.X = x;
             _pos.Y = y;
-            _leftButton   = ((buttons & 1) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            _rightButton  = ((buttons & 2) != 0) ? ButtonState.Pressed : ButtonState.Released;
-            _middleButton = ((buttons & 4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _leftButton   = ((buttons &  1) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _rightButton  = ((buttons &  2) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _middleButton = ((buttons &  4) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _xButton1     = ((buttons &  8) != 0) ? ButtonState.Pressed : ButtonState.Released;
+            _xButton2     = ((buttons & 16) != 0) ? ButtonState.Pressed : ButtonState.Released;
         }
 
         public void OnMouseWheel(object sender, int deltaX, int deltaY, int deltaZ, int deltaMode)

--- a/Platforms/Input/.Blazor/ConcreteMouse.cs
+++ b/Platforms/Input/.Blazor/ConcreteMouse.cs
@@ -116,7 +116,7 @@ namespace Microsoft.Xna.Platform.Input
 
         public void OnMouseWheel(object sender, int deltaX, int deltaY, int deltaZ, int deltaMode)
         {
-            _scrollX -= deltaX;
+            _scrollX += deltaX;
             _scrollY -= deltaY;
         }
 


### PR DESCRIPTION
This PR adds optional support for the mouse forward/back navigation buttons.

By default these will navigate the browser pages (which should probably remain the default behavior as what these buttons do is contextual to the webpage).

In order to override this if required though, the following can be added to the index.html file:
```js
window.addEventListener("mousedown", function (event)
{
    if (event.button === 3 || event.button === 4)
        event.preventDefault();
});
window.addEventListener("mouseup", function (event)
{
    if (event.button === 3 || event.button === 4)
        event.preventDefault();
});
```

Also this PR fixes the `MouseState.HorizontalScrollWheelValue`, which is currently operating in reverse compared to other platforms.