### PR TITLE
fix WinForms IsBorderless

### DIFF
--- a/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
+++ b/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Xna.Framework
                 _isResizable = value;
                 Form.MaximizeBox = _isResizable;
 
-                if (!IsBorderless)
-                    InternalSetFormBorderStyle(isBorderless: false);
+                if (!IsFullScreen)
+                    InternalSetFormBorderStyle(IsBorderless);
             }
         }
 

--- a/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
+++ b/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
@@ -553,7 +553,7 @@ namespace Microsoft.Xna.Framework
 
             ((IPlatformGraphicsDevice)_concreteGame.GraphicsDevice).Strategy.ToConcrete<ConcreteGraphicsDevice>().ClearHardwareFullscreen();
 
-            InternalSetFormBorderStyle(isBorderless: false);
+            InternalSetFormBorderStyle(IsBorderless);
             Form.WindowState = FormWindowState.Normal;
             _lastFormState = FormWindowState.Normal;
             Form.Location = _locationBeforeFullScreen;
@@ -572,7 +572,7 @@ namespace Microsoft.Xna.Framework
 
             ((IPlatformGraphicsDevice)_concreteGame.GraphicsDevice).Strategy.ToConcrete<ConcreteGraphicsDevice>().ClearHardwareFullscreen();
 
-            InternalSetFormBorderStyle(isBorderless: false);
+            InternalSetFormBorderStyle(IsBorderless);
             Form.WindowState = FormWindowState.Minimized;
             _lastFormState = FormWindowState.Minimized;
             Form.Location = _locationBeforeFullScreen;

--- a/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
+++ b/Platforms/Game/.WindowsDX11/WinFormsGameWindow.cs
@@ -97,7 +97,9 @@ namespace Microsoft.Xna.Framework
                     return;
 
                 _isBorderless = value;
-                InternalSetFormBorderStyle(_isBorderless);
+
+                if (!IsFullScreen)
+                    InternalSetFormBorderStyle(_isBorderless);
             }
         }
 


### PR DESCRIPTION
previously returning from SoftMode Fullscreen would set
GameWindow.IsBorderless to false.

Also, setting IsBorderless and AllowUserResizing during FullScreen ,
would change the window border and make it appear as if it's out of Soft mode Fullscreen.