### PR TITLE
Adds SamplerState.MinMipLevel & fixes SamplerState.MaxMipLevel

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsCapabilities.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsCapabilities.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Xna.Platform.Graphics
             SupportsDepth24 = false;
             SupportsPackedDepthStencil = false;
             SupportsDepthNonLinear = false;
-            SupportsTextureMaxLevel = false;
+            SupportsTextureMaxLevel = profile >= GraphicsProfile.HiDef;
 
             // 16bit textures
             SupportsBgra5551 = false;

--- a/Platforms/Graphics/.BlazorGL/States/ConcreteSamplerState.cs
+++ b/Platforms/Graphics/.BlazorGL/States/ConcreteSamplerState.cs
@@ -89,10 +89,10 @@ namespace Microsoft.Xna.Platform.Graphics
             // TextureMaxLevel
             if (cgraphicsContext.Capabilities.SupportsTextureMaxLevel)
             {
-                int textureMaxLevel = 1000;
-                if (this.MaxMipLevel > 0)
-                    textureMaxLevel = this.MaxMipLevel;
-                throw new NotImplementedException();
+                GL.TexParameter(target, WebGLTexParamName.TEXTURE_MIN_LOD, MaxMipLevel);
+                GL.CheckGLError();
+                GL.TexParameter(target, WebGLTexParamName.TEXTURE_MAX_LOD, Math.Min(MinMipLevel, 1000));
+                GL.CheckGLError();
             }
         }
 

--- a/Platforms/Graphics/.DX11/ConcreteGraphicsCapabilities.cs
+++ b/Platforms/Graphics/.DX11/ConcreteGraphicsCapabilities.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Platform.Graphics
             SupportsDepth24 = false;
             SupportsPackedDepthStencil = false;
             SupportsDepthNonLinear = false;
-            SupportsTextureMaxLevel = false;
+            SupportsTextureMaxLevel = profile >= GraphicsProfile.FL10_0;
 
             // 16bit textures
             SupportsBgra5551 = true;

--- a/Platforms/Graphics/.DX11/States/ConcreteSamplerState.cs
+++ b/Platforms/Graphics/.DX11/States/ConcreteSamplerState.cs
@@ -54,12 +54,17 @@ namespace Microsoft.Xna.Platform.Graphics
             samplerStateDesc.MipLodBias = MipMapLevelOfDetailBias;
             samplerStateDesc.ComparisonFunction = ComparisonFunction.ToDXComparisonFunction();
 
-            // TODO: How do i do this?
-            samplerStateDesc.MinimumLod = 0.0f;
-
-            // To support feature level 9.1 these must 
-            // be set to these exact values.
-            samplerStateDesc.MaximumLod = float.MaxValue;
+            if (contextStrategy.Capabilities.SupportsTextureMaxLevel)
+            {
+                samplerStateDesc.MinimumLod = MaxMipLevel;
+                samplerStateDesc.MaximumLod = MinMipLevel;
+            }
+            else
+            {
+                // To support feature level 9.1 these must be set to these exact values.
+                samplerStateDesc.MinimumLod = 0.0f;
+                samplerStateDesc.MaximumLod = float.MaxValue;
+            }
 
             // Create the state.
             return new D3D11.SamplerState(deviceStrategy.ToConcrete<ConcreteGraphicsDevice>().D3DDevice, samplerStateDesc);

--- a/Platforms/Graphics/.GL/ConcreteGraphicsCapabilities.cs
+++ b/Platforms/Graphics/.GL/ConcreteGraphicsCapabilities.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Xna.Platform.Graphics
 			SupportsDepth24 = GL.Extensions.Contains("GL_OES_depth24");
 			SupportsPackedDepthStencil = GL.Extensions.Contains("GL_OES_packed_depth_stencil");
 			SupportsDepthNonLinear = GL.Extensions.Contains("GL_NV_depth_nonlinear");
-            SupportsTextureMaxLevel = GL.Extensions.Contains("GL_APPLE_texture_max_level");
+            SupportsTextureMaxLevel = GL.BoundApi == OGL.RenderApi.ES && version >= new GLVersion(3,0);
 #elif DESKTOPGL
             SupportsDepth24 = true;
             SupportsPackedDepthStencil = true;

--- a/Platforms/Graphics/.GL/OpenGL.cs
+++ b/Platforms/Graphics/.GL/OpenGL.cs
@@ -468,6 +468,8 @@ namespace Microsoft.Xna.Platform.Graphics.OpenGL
     internal enum TextureParameterName
     {
         TextureMaxAnisotropyExt = 0x84FE,
+        TextureMinLod = 0x813A,
+        TextureMaxLod = 0x813B,
         TextureBaseLevel = 0x813C,
         TextureMaxLevel = 0x813D,
         TextureMinFilter = 0x2801,

--- a/Platforms/Graphics/.GL/States/ConcreteSamplerState.cs
+++ b/Platforms/Graphics/.GL/States/ConcreteSamplerState.cs
@@ -133,10 +133,9 @@ namespace Microsoft.Xna.Platform.Graphics
             // TextureMaxLevel
             if (cgraphicsContext.Capabilities.SupportsTextureMaxLevel)
             {
-                int textureMaxLevel = 1000;
-                if (this.MaxMipLevel > 0)
-                    textureMaxLevel = this.MaxMipLevel;
-                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureMaxLevel, textureMaxLevel);
+                GL.TexParameter(target, TextureParameterName.TextureMinLod, MaxMipLevel);
+                GL.CheckGLError();
+                GL.TexParameter(target, TextureParameterName.TextureMaxLod, MinMipLevel);
                 GL.CheckGLError();
             }
         }

--- a/src/Xna.Framework.Graphics/Graphics/States/ISamplerStateStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/States/ISamplerStateStrategy.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Xna.Platform.Graphics
         TextureAddressMode AddressW { get; set; }
         Color BorderColor { get; set; }
         int MaxAnisotropy { get; set; }
+        int MinMipLevel { get; set; }
         int MaxMipLevel { get; set; }
         float MipMapLevelOfDetailBias { get; set; }
         CompareFunction ComparisonFunction { get; set; }

--- a/src/Xna.Framework.Graphics/Graphics/States/ReadonlySamplerStateStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/States/ReadonlySamplerStateStrategy.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Xna.Platform.Graphics
             set { throw new InvalidOperationException("The state object is readonly."); }
         }
 
+        public override int MinMipLevel
+        {
+            get { return base.MinMipLevel; }
+            set { throw new InvalidOperationException("The state object is readonly."); }
+        }
+
         public override int MaxMipLevel
         {
             get { return base.MaxMipLevel; }

--- a/src/Xna.Framework.Graphics/Graphics/States/ResourceSamplerStateStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/States/ResourceSamplerStateStrategy.cs
@@ -45,6 +45,12 @@ namespace Microsoft.Xna.Platform.Graphics
             set { throw new InvalidOperationException("You cannot modify the state after it has been bound to the graphics device."); }
         }
 
+        public override int MinMipLevel
+        {
+            get { return base.MinMipLevel; }
+            set { throw new InvalidOperationException("You cannot modify the state after it has been bound to the graphics device."); }
+        }
+
         public override int MaxMipLevel
         {
             get { return base.MaxMipLevel; }

--- a/src/Xna.Framework.Graphics/Graphics/States/SamplerState.cs
+++ b/src/Xna.Framework.Graphics/Graphics/States/SamplerState.cs
@@ -73,6 +73,18 @@ namespace Microsoft.Xna.Framework.Graphics
             set { _strategy.MaxAnisotropy = value; }
         }
 
+        /// <summary>
+        /// Gets or sets the level of detail (LOD) index of the smallest map to use.
+        /// </summary>
+        public int MinMipLevel
+        {
+            get { return _strategy.MinMipLevel; }
+            set { _strategy.MinMipLevel = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the level of detail (LOD) index of the largest map to use.
+        /// </summary>
         public int MaxMipLevel
         {
             get { return _strategy.MaxMipLevel; }

--- a/src/Xna.Framework.Graphics/Graphics/States/SamplerStateStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/States/SamplerStateStrategy.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Xna.Platform.Graphics
         private TextureAddressMode _addressW;
         private Color _borderColor;
         private int _maxAnisotropy;
+        private int _minMipLevel;
         private int _maxMipLevel;
         private float _mipMapLevelOfDetailBias;
         private TextureFilterMode _filterMode;
@@ -56,6 +57,13 @@ namespace Microsoft.Xna.Platform.Graphics
             get { return _maxAnisotropy; }
             set { _maxAnisotropy = value; }
         }
+
+        public virtual int MinMipLevel
+        {
+            get { return _minMipLevel; }
+            set { _minMipLevel = value; }
+        }
+
         public virtual int MaxMipLevel
         {
             get { return _maxMipLevel; }
@@ -88,6 +96,7 @@ namespace Microsoft.Xna.Platform.Graphics
             _addressW = TextureAddressMode.Wrap;
             _borderColor = Color.White;
             _maxAnisotropy = 4;
+            _minMipLevel = int.MaxValue;
             _maxMipLevel = 0;
             _mipMapLevelOfDetailBias = 0.0f;
             _comparisonFunction = CompareFunction.Never;
@@ -103,6 +112,7 @@ namespace Microsoft.Xna.Platform.Graphics
             _addressW = source.AddressW;
             _borderColor = source.BorderColor;
             _maxAnisotropy = source.MaxAnisotropy;
+            _minMipLevel = source.MinMipLevel;
             _maxMipLevel = source.MaxMipLevel;
             _mipMapLevelOfDetailBias = source.MipMapLevelOfDetailBias;
             _comparisonFunction = source.ComparisonFunction;
@@ -118,6 +128,7 @@ namespace Microsoft.Xna.Platform.Graphics
             _addressW = source.AddressW;
             _borderColor = source.BorderColor;
             _maxAnisotropy = source.MaxAnisotropy;
+            _minMipLevel = source.MinMipLevel;
             _maxMipLevel = source.MaxMipLevel;
             _mipMapLevelOfDetailBias = source.MipMapLevelOfDetailBias;
             _comparisonFunction = source.ComparisonFunction;


### PR DESCRIPTION
Adds `SamplerState.MinMipLevel` property and also ensures `SamplerState.MaxMipLevel` matches XNA behavior, where "max" refers to the largest mipmap with the maximum level of detail. `<summary>` comments have been added to clarify this too.

The conditions for `GraphicsCapabilities.SupportsTextureMaxLevel` have also been corrected, including removing the "GL_APPLE_texture_max_level" extension check as this extension doesn't provide sampler min/max LOD support for texture filtering.

This PR is dependent on the following PR:
- https://github.com/nkast/Wasm/pull/26

For testing, this project can be used to adjust and view sampler state mip levels: https://github.com/squarebananas/XnaApiTesting