### PR TITLE
Texture2D fixes/implementations for OpenGL/GLES

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
@@ -154,6 +154,48 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+            var GL = contextStrategy.ToConcrete<ConcreteGraphicsContext>().GL;
+            bool isWebGL2 = (GL as IWebGL2RenderingContext) != null;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isWebGL2;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             //contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().EnsureContextCurrentThread();

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -60,6 +60,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -146,6 +146,29 @@ namespace Microsoft.Xna.Platform.Graphics
             }
 
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            checkedRight = checkedLeft + roundedWidth;
+            checkedBottom = checkedTop + roundedHeight;
+            checkedFront = front;
+            checkedBack = back;
+            return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.GL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture.cs
@@ -350,6 +350,49 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+#if GLES
+            bool isGLES3 = ((ConcreteGraphicsContextGL)contextStrategy)._glVersion.Major >= 3;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isGLES3;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+#endif
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             bool isSharedContext = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -215,8 +215,9 @@ namespace Microsoft.Xna.Platform.Graphics
 
                     if (_glIsCompressedTexture)
                     {
-                        w = w / 4;
-                        h = h / 4;
+                        Format.GetBlockSize(out int blockWidth, out int blockHeight);
+                        w = w / blockWidth;
+                        h = h / blockHeight;
                         int bytes = w * h * fSize;
                         IntPtr pTemp = Marshal.AllocHGlobal(bytes);
                         try
@@ -225,10 +226,10 @@ namespace Microsoft.Xna.Platform.Graphics
                             GL.CheckGLError();
 
                             IntPtr tempPtr = (IntPtr)pTemp;
-                            tempPtr = tempPtr + checkedRect.X / 4 * fSize + checkedRect.Top / 4 * w * fSize;
+                            tempPtr = tempPtr + checkedRect.X / blockWidth * fSize + checkedRect.Top / blockHeight * w * fSize;
                             int fWidthSize = w * fSize;
-                            int tRectWidthSize = checkedRect.Width / 4 * fSize;
-                            int rowCount = checkedRect.Height / 4;
+                            int tRectWidthSize = checkedRect.Width / blockWidth * fSize;
+                            int rowCount = checkedRect.Height / blockHeight;
                             for (int r = 0; r < rowCount; r++)
                             {
                                 MemCopyHelper.MemoryCopy(

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -298,7 +298,7 @@ namespace Microsoft.Xna.Platform.Graphics
             // round x and y down to next multiple of block size; width and height up to next multiple of block size
             int roundedWidth = (rect.Width + blockWidthMinusOne) & ~blockWidthMinusOne;
             int roundedHeight = (rect.Height + blockHeightMinusOne) & ~blockHeightMinusOne;
-            // OpenGL only: The last two mip levels require the width and height to be passed
+            // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
             checkedRect = new Rectangle(rect.X & ~blockWidthMinusOne, rect.Y & ~blockHeightMinusOne,
                                         (rect.Width < blockWidth && textureBounds.Width < blockWidth) ? textureBounds.Width : roundedWidth,

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -245,10 +245,9 @@ namespace Microsoft.Xna.Platform.Graphics
                     }
                     else
                     {
-                        if (level == 0
-                        &&  checkedRect.X == 0 && checkedRect.Y == 0
-                        &&  checkedRect.Width == this.Width && checkedRect.Height == this.Height
-                        &&  startIndex == 0 && elementCount == data.Length)
+                        if (checkedRect.X == 0 && checkedRect.Y == 0
+                        && checkedRect.Width == w && checkedRect.Height == h
+                        && startIndex == 0 && elementCount == data.Length)
                         {
                             GL.GetTexImage(TextureTarget.Texture2D, level, _glFormat, _glType, dataPtr);
                             GL.CheckGLError();

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -170,13 +170,14 @@ namespace Microsoft.Xna.Platform.Graphics
         public unsafe void GetData<T>(int level, int arraySlice, Rectangle checkedRect, T[] data, int startIndex, int elementCount)
             where T : struct
         {
-            bool isSharedContext = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();
+            GraphicsContextStrategy contextStrategy = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy;
+            bool isSharedContext = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();
             try
             {
-                var GL = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
+                var GL = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
 
 #if GLES
-                // TODO: check for non renderable formats (formats that can't be attached to FBO)
+                ValidateGetDataSurfaceFormat(Format, contextStrategy);
 
                 int framebufferId = 0;
                 framebufferId = GL.GenFramebuffer();
@@ -284,7 +285,7 @@ namespace Microsoft.Xna.Platform.Graphics
             }
             finally
             {
-                ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindSharedContext();
+                contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindSharedContext();
             }
         }
 

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -184,7 +184,7 @@ namespace Microsoft.Xna.Platform.Graphics
                 GL.CheckGLError();
                 GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferId);
                 GL.CheckGLError();
-                GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, _glTexture, 0);
+                GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, TextureTarget.Texture2D, _glTexture, level);
                 GL.CheckGLError();
 
                 fixed (T* pData = &data[0])

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -189,7 +189,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
                 fixed (T* pData = &data[0])
                 {
-                    IntPtr dataPtr = (IntPtr)pData;
+                    IntPtr dataPtr = (IntPtr)pData + (startIndex * Format.GetSize());
                     GL.ReadPixels(checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height, _glFormat, _glType, dataPtr);
                     GL.CheckGLError();
                 }

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -351,27 +351,10 @@ namespace Microsoft.Xna.Platform.Graphics
                 {
                     if (_glIsCompressedTexture)
                     {
-                        int imageSize = 0;
-                        // PVRTC has explicit calculations for imageSize
-                        // https://www.khronos.org/registry/OpenGL/extensions/IMG/IMG_texture_compression_pvrtc.txt
-                        if (format == SurfaceFormat.RgbPvrtc2Bpp || format == SurfaceFormat.RgbaPvrtc2Bpp)
-                        {
-                            imageSize = (Math.Max(w, 16) * Math.Max(h, 8) * 2 + 7) / 8;
-                        }
-                        else if (format == SurfaceFormat.RgbPvrtc4Bpp || format == SurfaceFormat.RgbaPvrtc4Bpp)
-                        {
-                            imageSize = (Math.Max(w, 8) * Math.Max(h, 8) * 4 + 7) / 8;
-                        }
-                        else
-                        {
-                            int blockSize = format.GetSize();
-                            int blockWidth, blockHeight;
-                            format.GetBlockSize(out blockWidth, out blockHeight);
-                            int wBlocks = (w + (blockWidth - 1)) / blockWidth;
-                            int hBlocks = (h + (blockHeight - 1)) / blockHeight;
-                            imageSize = wBlocks * hBlocks * blockSize;
-                        }
-                        GL.CompressedTexImage2D(TextureTarget.Texture2D, level, _glInternalFormat, w, h, 0, imageSize, IntPtr.Zero);
+                        Rectangle bounds = new Rectangle(0, 0, w, h);
+                        int dataSize = GetCompressedDataByteSize(format.GetSize(), bounds, ref bounds, out Rectangle checkedRect);
+                        GL.CompressedTexImage2D(TextureTarget.Texture2D, level, _glInternalFormat, checkedRect.Width, checkedRect.Height, 0,
+                                                dataSize, IntPtr.Zero);
                         GL.CheckGLError();
                     }
                     else

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -98,6 +98,7 @@ namespace Microsoft.Xna.Platform.Graphics
                     GL.CheckGLError();
 
                     GL.PixelStore(PixelStoreParameter.UnpackAlignment, Math.Min(fSize, 8));
+                    GL.CheckGLError();
 
                     if (_glIsCompressedTexture)
                     {
@@ -144,6 +145,7 @@ namespace Microsoft.Xna.Platform.Graphics
                     GL.CheckGLError();
 
                     GL.PixelStore(PixelStoreParameter.UnpackAlignment, Math.Min(fSize, 8));
+                    GL.CheckGLError();
 
                     if (_glIsCompressedTexture)
                     {
@@ -206,7 +208,10 @@ namespace Microsoft.Xna.Platform.Graphics
                 GL.ActiveTexture(TextureUnit.Texture0 + 0);
                 GL.CheckGLError();
                 GL.BindTexture(TextureTarget.Texture2D, _glTexture);
+                GL.CheckGLError();
+
                 GL.PixelStore(PixelStoreParameter.PackAlignment, Math.Min(TsizeInBytes, 8));
+                GL.CheckGLError();
 
                 fixed (T* pData = &data[0])
                 {

--- a/Platforms/Graphics/.GL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture2D.cs
@@ -344,13 +344,6 @@ namespace Microsoft.Xna.Platform.Graphics
                 GL.BindTexture(TextureTarget.Texture2D, _glTexture);
                 GL.CheckGLError();
 
-                // Set mipMap levels
-#if !GLES
-                GL.TexParameter(TextureTarget.Texture2D, TextureParameterName.TextureBaseLevel, 0);
-                GL.CheckGLError();
-#endif
-
-
                 int w = width;
                 int h = height;
                 int level = 0;

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -91,6 +91,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
 

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
@@ -17,5 +17,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         void SetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
         void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
+        int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+            int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+            out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom, out int checkedFront, out int checkedBack);
     }
 }

--- a/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
+++ b/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -68,7 +70,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -77,8 +81,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);
-            _strategyTexture3D.SetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.SetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -100,8 +107,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);                       
-            _strategyTexture3D.GetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.GetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -115,7 +125,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -128,7 +140,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -143,9 +157,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data array is too small.");
         }
 
-        private unsafe void ValidateParams<T>(int level,
-                                       int left, int top, int right, int bottom, int front, int back,
-                                       int elementCount)
+        private unsafe void ValidateParams<T>(int level, int left, int top, int right, int bottom, int front, int back, int elementCount,
+                                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                              out int checkedFront, out int checkedBack)
             where T : struct
         {
             int tSize = sizeof(T);
@@ -168,7 +182,24 @@ namespace Microsoft.Xna.Framework.Graphics
             if (level < 0 || level >= LevelCount)
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
 
-            int dataByteSize = width*height*depth*fSize;
+            int dataByteSize;
+            if (Format.IsCompressedFormat())
+            {
+                dataByteSize = _strategyTexture3D.GetCompressedDataByteSize(
+                    fSize, left, top, right, bottom, front, back, texWidth, texHeight, texDepth,
+                    out checkedLeft, out checkedTop, out checkedRight, out checkedBottom, out checkedFront, out checkedBack);
+            }
+            else
+            {
+                checkedLeft = left;
+                checkedTop = top;
+                checkedRight = right;
+                checkedBottom = bottom;
+                checkedFront = front;
+                checkedBack = back;
+                dataByteSize = width * height * depth * fSize;
+            }
+
             if (elementCount * tSize != dataByteSize)
                 throw new ArgumentException(string.Format("elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
@@ -176,4 +207,3 @@ namespace Microsoft.Xna.Framework.Graphics
         }
     }
 }
-


### PR DESCRIPTION
Texture2D fixes/implementations for OpenGL/GLES.

Implements:
- GLES `ValidateGetDataSurfaceFormat` for checking unsupported `SurfaceFormat` types.

Fixes:
- GLES `GetData` with `startIndex` argument.
- GLES `GetData` with `level` argument.
- Missing `CheckGLError` checks.
- Removes incorrect "OpenGL only" comment as it relates to GLES too.

Other improvements:
- OpenGL `GetData` now uses `Format.GetBlockSize` (instead of hardcoded 4x4 block sizes).
- OpenGL `GetData` allows full read for levels other than level 0 (prevents unnecessary `Marshal.AllocHGlobal(bytes)`).
- Removes unnecessary setting of `TextureBaseLevel` for OpenGL (already not used for other texture types).
- Replaces duplicate compressed size calculations with call to `GetCompressedDataByteSize`.

This PR is dependent on the following PRs:
- https://github.com/kniEngine/kni/pull/2636
- https://github.com/kniEngine/kni/pull/2635

Test project: https://github.com/squarebananas/XnaApiTesting