### PR TITLE
TextureCube fixes/implementations for OpenGL/GLES

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
@@ -154,6 +154,48 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+            var GL = contextStrategy.ToConcrete<ConcreteGraphicsContext>().GL;
+            bool isWebGL2 = (GL as IWebGL2RenderingContext) != null;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isWebGL2;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             //contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().EnsureContextCurrentThread();

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -60,6 +60,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -146,6 +146,29 @@ namespace Microsoft.Xna.Platform.Graphics
             }
 
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            checkedRight = checkedLeft + roundedWidth;
+            checkedBottom = checkedTop + roundedHeight;
+            checkedFront = front;
+            checkedBack = back;
+            return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.GL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture.cs
@@ -350,6 +350,49 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+#if GLES
+            bool isGLES3 = ((ConcreteGraphicsContextGL)contextStrategy)._glVersion.Major >= 3;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isGLES3;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+#endif
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             bool isSharedContext = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -91,6 +91,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
 

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -89,13 +89,32 @@ namespace Microsoft.Xna.Platform.Graphics
         public unsafe void GetData<T>(CubeMapFace face, int level, Rectangle checkedRect, T[] data, int startIndex, int elementCount)
             where T : struct
         {
-            bool isSharedContext = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();
+            GraphicsContextStrategy contextStrategy = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy;
+            bool isSharedContext = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();
             try
             {
-                var GL = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
-
-#if OPENGL && DESKTOPGL
+                var GL = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().GL;
                 TextureTarget target = ConcreteTextureCube.GetGLCubeFace(face);
+
+#if GLES
+                ValidateGetDataSurfaceFormat(Format, contextStrategy);
+
+                int framebufferId = 0;
+                framebufferId = GL.GenFramebuffer();
+                GL.CheckGLError();
+                GL.BindFramebuffer(FramebufferTarget.Framebuffer, framebufferId);
+                GL.CheckGLError();
+                GL.FramebufferTexture2D(FramebufferTarget.Framebuffer, FramebufferAttachment.ColorAttachment0, target, _glTexture, level);
+                GL.CheckGLError();
+
+                fixed (T* pData = &data[0])
+                {
+                    IntPtr dataPtr = (IntPtr)pData + (startIndex * Format.GetSize());
+                    GL.ReadPixels(checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height, _glFormat, _glType, dataPtr);
+                    GL.CheckGLError();
+                }
+                GL.DeleteFramebuffer(framebufferId);
+#else
                 // Note: for compressed format Format.GetSize() returns the size of a 4x4 block
                 int fSize = this.Format.GetSize();
                 int w = Math.Max(this.Size >> level, 1);
@@ -181,13 +200,11 @@ namespace Microsoft.Xna.Platform.Graphics
                         }
                     }
                 }
-#else
-                throw new NotImplementedException();
 #endif
             }
             finally
             {
-                ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindSharedContext();
+                contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().UnbindSharedContext();
             }
         }
 

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -228,7 +228,7 @@ namespace Microsoft.Xna.Platform.Graphics
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
             {
                 return (Math.Max(checkedRect.Width, 16) * Math.Max(checkedRect.Height, 8) * 2 + 7) / 8;
-        }
+            }
             else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
             {
                 return (Math.Max(checkedRect.Width, 8) * Math.Max(checkedRect.Height, 8) * 4 + 7) / 8;
@@ -293,32 +293,29 @@ namespace Microsoft.Xna.Platform.Graphics
                 {
                     TextureTarget target = ConcreteTextureCube.GetGLCubeFace((CubeMapFace)i);
 
-                    if (_glIsCompressedTexture)
+                    int s = size;
+                    int level = 0;
+                    while (true)
                     {
+                        if (_glIsCompressedTexture)
+                        {
                             Rectangle bounds = new Rectangle(0, 0, s, s);
                             int dataSize = GetCompressedDataByteSize(format.GetSize(), bounds, ref bounds, out Rectangle checkedRect);
                             GL.CompressedTexImage2D(target, level, _glInternalFormat, checkedRect.Width, checkedRect.Height, 0, dataSize, IntPtr.Zero);
-                        GL.CheckGLError();
-                    }
-                    else
-                    {
-                        GL.TexImage2D(target, 0, _glInternalFormat, size, size, 0, _glFormat, _glType, IntPtr.Zero);
-                        GL.CheckGLError();
-                    }
-                }
+                            GL.CheckGLError();
+                        }
+                        else
+                        {
+                            GL.TexImage2D(target, level, _glInternalFormat, s, s, 0, _glFormat, _glType, IntPtr.Zero);
+                            GL.CheckGLError();
+                        }
 
-                if (mipMap)
-                {
-                    System.Diagnostics.Debug.Assert(TextureTarget.TextureCubeMap == _glTarget);
-#if IOS || TVOS || ANDROID
-                    GL.GenerateMipmap(TextureTarget.TextureCubeMap);
-                    GL.CheckGLError();
-#else
-                    GL.GenerateMipmap(_glTarget);
-                    GL.CheckGLError();
-                    // This updates the mipmaps after a change in the base texture
-                    GL.TexParameter(TextureTarget.TextureCubeMap, TextureParameterName.GenerateMipmap, (int)Bool.True);
-#endif
+                        if ((s == 1) || !mipMap)
+                            break;
+                        if (s > 1)
+                            s = s / 2;
+                        ++level;
+                    }
                 }
             }
             finally

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -295,39 +295,9 @@ namespace Microsoft.Xna.Platform.Graphics
 
                     if (_glIsCompressedTexture)
                     {
-                        int imageSize = 0;
-                        switch (format)
-                        {
-                            case SurfaceFormat.RgbPvrtc2Bpp:
-                            case SurfaceFormat.RgbaPvrtc2Bpp:
-                                imageSize = (Math.Max(size, 16) * Math.Max(size, 8) * 2 + 7) / 8;
-                                break;
-                            case SurfaceFormat.RgbPvrtc4Bpp:
-                            case SurfaceFormat.RgbaPvrtc4Bpp:
-                                imageSize = (Math.Max(size, 8) * Math.Max(size, 8) * 4 + 7) / 8;
-                                break;
-                            case SurfaceFormat.Dxt1:
-                            case SurfaceFormat.Dxt1a:
-                            case SurfaceFormat.Dxt1SRgb:
-                            case SurfaceFormat.Dxt3:
-                            case SurfaceFormat.Dxt3SRgb:
-                            case SurfaceFormat.Dxt5:
-                            case SurfaceFormat.Dxt5SRgb:
-                            case SurfaceFormat.RgbEtc1:
-                            case SurfaceFormat.Rgb8Etc2:
-                            case SurfaceFormat.Srgb8Etc2:
-                            case SurfaceFormat.Rgb8A1Etc2:
-                            case SurfaceFormat.Srgb8A1Etc2:
-                            case SurfaceFormat.Rgba8Etc2:
-                            case SurfaceFormat.SRgb8A8Etc2:
-                            case SurfaceFormat.RgbaAtcExplicitAlpha:
-                            case SurfaceFormat.RgbaAtcInterpolatedAlpha:
-                                imageSize = (size + 3) / 4 * ((size + 3) / 4) * format.GetSize();
-                                break;
-                            default:
-                                throw new NotSupportedException();
-                        }
-                        GL.CompressedTexImage2D(target, 0, _glInternalFormat, size, size, 0, imageSize, IntPtr.Zero);
+                            Rectangle bounds = new Rectangle(0, 0, s, s);
+                            int dataSize = GetCompressedDataByteSize(format.GetSize(), bounds, ref bounds, out Rectangle checkedRect);
+                            GL.CompressedTexImage2D(target, level, _glInternalFormat, checkedRect.Width, checkedRect.Height, 0, dataSize, IntPtr.Zero);
                         GL.CheckGLError();
                     }
                     else

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -126,6 +126,10 @@ namespace Microsoft.Xna.Platform.Graphics
                 GL.ActiveTexture(TextureUnit.Texture0 + 0);
                 GL.CheckGLError();
                 GL.BindTexture(TextureTarget.TextureCubeMap, _glTexture);
+                GL.CheckGLError();
+
+                GL.PixelStore(PixelStoreParameter.PackAlignment, Math.Min(TsizeInBytes, 8));
+                GL.CheckGLError();
 
                 fixed (T* pData = &data[0])
                 {

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -134,8 +134,9 @@ namespace Microsoft.Xna.Platform.Graphics
 
                     if (_glIsCompressedTexture)
                     {
-                        w = w / 4;
-                        h = h / 4;
+                        Format.GetBlockSize(out int blockWidth, out int blockHeight);
+                        w = w / blockWidth;
+                        h = h / blockHeight;
                         int bytes = w * h * fSize;
                         IntPtr pTemp = Marshal.AllocHGlobal(bytes);
                         try
@@ -144,10 +145,10 @@ namespace Microsoft.Xna.Platform.Graphics
                             GL.CheckGLError();
 
                             IntPtr tempPtr = (IntPtr)pTemp;
-                            tempPtr = tempPtr + checkedRect.X / 4 * fSize + checkedRect.Top / 4 * w * fSize;
+                            tempPtr = tempPtr + checkedRect.X / blockWidth * fSize + checkedRect.Top / blockHeight * w * fSize;
                             int fWidthSize = w * fSize;
-                            int tRectWidthSize = checkedRect.Width / 4 * fSize;
-                            int rowCount = checkedRect.Height / 4;
+                            int tRectWidthSize = checkedRect.Width / blockWidth * fSize;
+                            int rowCount = checkedRect.Height / blockHeight;
                             for (int r = 0; r < rowCount; r++)
                             {
                                 MemCopyHelper.MemoryCopy(

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -210,15 +210,29 @@ namespace Microsoft.Xna.Platform.Graphics
 
         public int GetCompressedDataByteSize(int fSize, Rectangle rect, ref Rectangle textureBounds, out Rectangle checkedRect)
         {
-            // round x and y down to next multiple of four; width and height up to next multiple of four
-            int roundedWidth = (rect.Width + 3) & ~0x3;
-            int roundedHeight = (rect.Height + 3) & ~0x3;
-            // OpenGL only: The last two mip levels require the width and height to be passed
-            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a 4x4 block.
-            checkedRect = new Rectangle(rect.X & ~0x3, rect.Y & ~0x3,
-                                        (rect.Width < 4 && textureBounds.Width < 4) ? textureBounds.Width : roundedWidth,
-                                        (rect.Height < 4 && textureBounds.Height < 4) ? textureBounds.Height : roundedHeight);
-            return (roundedWidth * roundedHeight * fSize / 16);
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (rect.Width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (rect.Height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRect = new Rectangle(rect.X & ~blockWidthMinusOne, rect.Y & ~blockHeightMinusOne,
+                                        (rect.Width < blockWidth && textureBounds.Width < blockWidth) ? textureBounds.Width : roundedWidth,
+                                        (rect.Height < blockHeight && textureBounds.Height < blockHeight) ? textureBounds.Height : roundedHeight);
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRect.Width, 16) * Math.Max(checkedRect.Height, 8) * 2 + 7) / 8;
+        }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRect.Width, 8) * Math.Max(checkedRect.Height, 8) * 4 + 7) / 8;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight);
+            }
         }
         #endregion ITextureCubeStrategy
 

--- a/Platforms/Graphics/.GL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.GL/ConcreteTextureCube.cs
@@ -164,9 +164,8 @@ namespace Microsoft.Xna.Platform.Graphics
                     }
                     else
                     {
-                        if (level == 0
-                        && checkedRect.X == 0 && checkedRect.Y == 0
-                        && checkedRect.Width == this.Size && checkedRect.Height == this.Size
+                        if (checkedRect.X == 0 && checkedRect.Y == 0
+                        && checkedRect.Width == w && checkedRect.Height == h
                         && startIndex == 0 && elementCount == data.Length)
                         {
                             GL.GetTexImage(target, level, _glFormat, _glType, dataPtr);

--- a/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
@@ -17,5 +17,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         void SetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
         void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
+        int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+            int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+            out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom, out int checkedFront, out int checkedBack);
     }
 }

--- a/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
+++ b/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -68,7 +70,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -77,8 +81,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);
-            _strategyTexture3D.SetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.SetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -100,8 +107,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);                       
-            _strategyTexture3D.GetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.GetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -115,7 +125,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -128,7 +140,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -143,9 +157,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data array is too small.");
         }
 
-        private unsafe void ValidateParams<T>(int level,
-                                       int left, int top, int right, int bottom, int front, int back,
-                                       int elementCount)
+        private unsafe void ValidateParams<T>(int level, int left, int top, int right, int bottom, int front, int back, int elementCount,
+                                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                              out int checkedFront, out int checkedBack)
             where T : struct
         {
             int tSize = sizeof(T);
@@ -168,7 +182,24 @@ namespace Microsoft.Xna.Framework.Graphics
             if (level < 0 || level >= LevelCount)
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
 
-            int dataByteSize = width*height*depth*fSize;
+            int dataByteSize;
+            if (Format.IsCompressedFormat())
+            {
+                dataByteSize = _strategyTexture3D.GetCompressedDataByteSize(
+                    fSize, left, top, right, bottom, front, back, texWidth, texHeight, texDepth,
+                    out checkedLeft, out checkedTop, out checkedRight, out checkedBottom, out checkedFront, out checkedBack);
+            }
+            else
+            {
+                checkedLeft = left;
+                checkedTop = top;
+                checkedRight = right;
+                checkedBottom = bottom;
+                checkedFront = front;
+                checkedBack = back;
+                dataByteSize = width * height * depth * fSize;
+            }
+
             if (elementCount * tSize != dataByteSize)
                 throw new ArgumentException(string.Format("elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
@@ -176,4 +207,3 @@ namespace Microsoft.Xna.Framework.Graphics
         }
     }
 }
-


### PR DESCRIPTION
TextureCube fixes/implementations for OpenGL/GLES.

Implements:
- Mipmap support.
- GLES `GetData` support.

Fixes:
- Missing `GetCompressedDataByteSize` format calculations (now matches `Texture2D` version).
- OpenGL `GetData` missing `PackAlignment` & `CheckGLError` check.

Other improvements:
- OpenGL `GetData` now uses `Format.GetBlockSize` (instead of hardcoded 4x4 block sizes).
- OpenGL `GetData` allows full read for levels other than level 0 (prevents unnecessary `Marshal.AllocHGlobal(bytes)`).
- Replaces duplicate compressed size calculations with call to `GetCompressedDataByteSize`.

This PR is dependent on the following PRs:
- https://github.com/kniEngine/kni/pull/2636
- https://github.com/kniEngine/kni/pull/2635

Test project: https://github.com/squarebananas/XnaApiTesting