### PR TITLE
Implements SamplerState.AddressW for OpenGL/GLES

### DIFF
--- a/Platforms/Graphics/.GL/ConcreteGraphicsCapabilities.cs
+++ b/Platforms/Graphics/.GL/ConcreteGraphicsCapabilities.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Xna.Platform.Graphics
 
         internal int MaxDrawBuffers { get { return _maxDrawBuffers; } }
 
+        internal bool SupportsTexture3D { get; private set; }
 
         internal void PlatformInitialize(ConcreteGraphicsContextGL cgraphicsContext, GraphicsDeviceStrategy deviceStrategy, GLVersion version)
         {
@@ -164,6 +165,9 @@ namespace Microsoft.Xna.Platform.Graphics
 
             GL.GetInteger(GetParamName.MaxDrawBuffers, out _maxDrawBuffers);
             GL.CheckGLError();
+
+            SupportsTexture3D = (GL.BoundApi == OGL.RenderApi.GL && version >= new GLVersion(1, 2))
+                             || (GL.BoundApi == OGL.RenderApi.ES && version >= new GLVersion(3, 0));
         }
 
     }

--- a/Platforms/Graphics/.GL/OpenGL.cs
+++ b/Platforms/Graphics/.GL/OpenGL.cs
@@ -474,6 +474,7 @@ namespace Microsoft.Xna.Platform.Graphics.OpenGL
         TextureMagFilter = 0x2800,
         TextureWrapS = 0x2802,
         TextureWrapT = 0x2803,
+        TextureWrapR = 0x8072,
         TextureBorderColor = 0x1004,
         TextureLodBias = 0x8501,
         TextureCompareMode = 0x884C,

--- a/Platforms/Graphics/.GL/States/ConcreteSamplerState.cs
+++ b/Platforms/Graphics/.GL/States/ConcreteSamplerState.cs
@@ -100,6 +100,11 @@ namespace Microsoft.Xna.Platform.Graphics
             GL.CheckGLError();
             GL.TexParameter(target, TextureParameterName.TextureWrapT, (int)ToGLTextureAddressMode(AddressV));
             GL.CheckGLError();
+            if (((ConcreteGraphicsCapabilities)cgraphicsContext.Capabilities).SupportsTexture3D)
+            {
+                GL.TexParameter(target, TextureParameterName.TextureWrapR, (int)ToGLTextureAddressMode(AddressW));
+                GL.CheckGLError();
+            }
 
 #if !GLES
             // Border color is not supported by glTexParameter in OpenGL ES 2.0


### PR DESCRIPTION
Implements `SamplerState.AddressW` for OpenGL/GLES, which in turn allows the 3rd dimension of a `Texture3D` to be set for wrap/clamp/mirror texture addressing.