### PR TITLE
Texture3D compressed format support for DX11

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -60,6 +60,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Xna.Platform.Graphics
         public int Depth { get { return _depth; } }
 
         public unsafe void SetData<T>(int level, int left, int top, int right, int bottom, int front, int back,
-                               T[] data, int startIndex, int elementCount)
+                                      T[] data, int startIndex, int elementCount)
             where T : struct
         {
             int width = right - left;
@@ -89,16 +89,21 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
-        public void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back,
-                               T[] data, int startIndex, int elementCount)
+        public unsafe void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back,
+                                      T[] data, int startIndex, int elementCount)
              where T : struct
         {
             // Create a temp staging resource for copying the data.
             //
+            int min = this.Format.IsCompressedFormat() ? 4 : 1;
+            int levelWidth = Math.Max(this.Width >> level, min);
+            int levelHeight = Math.Max(this.Height >> level, min);
+            int levelDepth = Math.Max(this.Depth >> level, min);
+
             D3D11.Texture3DDescription texture3DDesc = new D3D11.Texture3DDescription();
-            texture3DDesc.Width = this.Width;
-            texture3DDesc.Height = this.Height;
-            texture3DDesc.Depth = this.Depth;
+            texture3DDesc.Width = levelWidth;
+            texture3DDesc.Height = levelHeight;
+            texture3DDesc.Depth = levelDepth;
             texture3DDesc.MipLevels = 1;
             texture3DDesc.Format = this.Format.ToDXFormat();
             texture3DDesc.BindFlags = D3D11.BindFlags.None;
@@ -120,21 +125,70 @@ namespace Microsoft.Xna.Platform.Graphics
                     DX.DataBox dataBox = d3dContext.MapSubresource(stagingTexture, 0, D3D11.MapMode.Read, D3D11.MapFlags.None, out stream);
                     try
                     {
-                        // Some drivers may add pitch to rows or slices.
-                        // We need to copy each row separatly and skip trailing zeros.
-                        int currentIndex = startIndex;
                         int elementSize = this.Format.GetSize();
                         int elementsInRow = right - left;
                         int rowsInSlice = bottom - top;
-                        for (int slice = front; slice < back; slice++)
+                        int slices = back - front;
+                        if (this.Format.IsCompressedFormat())
                         {
-                            for (int row = top; row < bottom; row++)
+                            // for 4x4 block compression formats an element is one block, so elementsInRow
+                            // and number of rows are 1/4 of number of pixels in width and height
+                            elementsInRow /= 4;
+                            rowsInSlice /= 4;
+                        }
+                        int rowSize = elementSize * elementsInRow;
+                        int sliceSize = rowSize * rowsInSlice;
+                        if ((rowSize == dataBox.RowPitch) && (sliceSize == dataBox.SlicePitch))
+                            stream.ReadRange(data, startIndex, elementCount);
+                        else if (left == 0 && top == 0 && front == 0 &&
+                                 right == levelWidth && bottom == levelHeight && back == levelDepth &&
+                                 startIndex == 0 && elementCount == data.Length)
+                        {
+                            // Optimized PlatformGetData() that reads multiple elements in a row when texture has rowPitch
+                            int elementSize2 = sizeof(T);
+                            if (elementSize2 == 1) // byte[]
+                                elementsInRow = elementsInRow * elementSize;
+
+                            int currentIndex = 0;
+                            for (int slice = front; slice < back; slice++)
                             {
-                                stream.ReadRange(data, currentIndex, elementsInRow);
-                                stream.Seek(dataBox.RowPitch - (elementSize * elementsInRow), SeekOrigin.Current);
-                                currentIndex += elementsInRow;
+                                for (int row = 0; row < rowsInSlice; row++)
+                                {
+                                    stream.ReadRange(data, currentIndex, elementsInRow);
+                                    stream.Seek(dataBox.RowPitch - rowSize, SeekOrigin.Current);
+                                    currentIndex += elementsInRow;
+                                }
+                                stream.Seek(dataBox.SlicePitch - (dataBox.RowPitch * rowsInSlice), SeekOrigin.Current);
                             }
-                            stream.Seek(dataBox.SlicePitch - (dataBox.RowPitch * rowsInSlice), SeekOrigin.Current);
+                        }
+                        else
+                        {
+                            // Some drivers may add pitch to rows or slices.
+                            // We need to copy each row separately and skip trailing zeros.
+                            stream.Seek(0, SeekOrigin.Begin);
+
+                            int elementSizeInByte = sizeof(T);
+                            for (int slice = 0; slice < slices; slice++)
+                            {
+                                int dataSliceOffset = slice * sliceSize / elementSizeInByte;
+                                for (int row = 0; row < rowsInSlice; row++)
+                                {
+                                    int i;
+                                    int maxElements = (row + 1) * rowSize / elementSizeInByte;
+                                    for (i = row * rowSize / elementSizeInByte; i < maxElements; i++)
+                                        data[i + dataSliceOffset + startIndex] = stream.Read<T>();
+
+                                    if ((i + dataSliceOffset) >= elementCount)
+                                        break;
+
+                                    stream.Seek(dataBox.RowPitch - rowSize, SeekOrigin.Current);
+                                }
+
+                                if ((dataSliceOffset + (rowsInSlice * elementsInRow)) >= elementCount)
+                                    break;
+
+                                stream.Seek(dataBox.SlicePitch - (dataBox.RowPitch * rowsInSlice), SeekOrigin.Current);
+                            }
                         }
                     }
                     finally
@@ -145,7 +199,6 @@ namespace Microsoft.Xna.Platform.Graphics
                     }
                 }
             }
-
         }
 
         public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -72,7 +72,8 @@ namespace Microsoft.Xna.Platform.Graphics
                 dataPtr = dataPtr + startIndex * elementSizeInByte;
 
                 int rowPitch = this.Format.GetPitch(width);
-                int slicePitch = rowPitch * height; // For 3D texture: Size of 2D image.
+                int rowCount = this.Format.IsCompressedFormat() ? ((height + 3) / 4) : height;
+                int slicePitch = rowPitch * rowCount; // For 3D texture: Size of 2D image.
                 DX.DataBox dataBox = new DX.DataBox(dataPtr, rowPitch, slicePitch);
 
                 int subresourceIndex = level;

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -146,6 +146,29 @@ namespace Microsoft.Xna.Platform.Graphics
             }
 
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            checkedRight = checkedLeft + roundedWidth;
+            checkedBottom = checkedTop + roundedHeight;
+            checkedFront = front;
+            checkedBack = back;
+            return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -91,6 +91,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
 

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
@@ -17,5 +17,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         void SetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
         void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
+        int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+            int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+            out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom, out int checkedFront, out int checkedBack);
     }
 }

--- a/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
+++ b/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -68,7 +70,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -77,8 +81,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);
-            _strategyTexture3D.SetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.SetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -100,8 +107,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);                       
-            _strategyTexture3D.GetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.GetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -115,7 +125,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -128,7 +140,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -143,9 +157,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data array is too small.");
         }
 
-        private unsafe void ValidateParams<T>(int level,
-                                       int left, int top, int right, int bottom, int front, int back,
-                                       int elementCount)
+        private unsafe void ValidateParams<T>(int level, int left, int top, int right, int bottom, int front, int back, int elementCount,
+                                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                              out int checkedFront, out int checkedBack)
             where T : struct
         {
             int tSize = sizeof(T);
@@ -168,7 +182,24 @@ namespace Microsoft.Xna.Framework.Graphics
             if (level < 0 || level >= LevelCount)
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
 
-            int dataByteSize = width*height*depth*fSize;
+            int dataByteSize;
+            if (Format.IsCompressedFormat())
+            {
+                dataByteSize = _strategyTexture3D.GetCompressedDataByteSize(
+                    fSize, left, top, right, bottom, front, back, texWidth, texHeight, texDepth,
+                    out checkedLeft, out checkedTop, out checkedRight, out checkedBottom, out checkedFront, out checkedBack);
+            }
+            else
+            {
+                checkedLeft = left;
+                checkedTop = top;
+                checkedRight = right;
+                checkedBottom = bottom;
+                checkedFront = front;
+                checkedBack = back;
+                dataByteSize = width * height * depth * fSize;
+            }
+
             if (elementCount * tSize != dataByteSize)
                 throw new ArgumentException(string.Format("elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
@@ -176,4 +207,3 @@ namespace Microsoft.Xna.Framework.Graphics
         }
     }
 }
-


### PR DESCRIPTION
Texture3D implementations/improvements for DX11.

Implements:
- `SetData` compressed `SurfaceFormat` support.
- `GetData` compressed `SurfaceFormat` support.

Other improvements:
- `GetData` now has three paths (full read, row read & element read) depending on alignment & region requested, to match the existing optimized `Texture2D` & `TextureCube` code.

This PR is dependent on the following PR:
- https://github.com/kniEngine/kni/pull/2635

Test project: https://github.com/squarebananas/XnaApiTesting