### PR TITLE
TextureCube fixes/implementations for BlazorGL

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture.cs
@@ -154,6 +154,48 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+            var GL = contextStrategy.ToConcrete<ConcreteGraphicsContext>().GL;
+            bool isWebGL2 = (GL as IWebGL2RenderingContext) != null;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isWebGL2;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             //contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().EnsureContextCurrentThread();

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -79,8 +79,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture3D.cs
@@ -60,6 +60,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
@@ -91,20 +91,29 @@ namespace Microsoft.Xna.Platform.Graphics
 
         public int GetCompressedDataByteSize(int fSize, Rectangle rect, ref Rectangle textureBounds, out Rectangle checkedRect)
         {
-            // round x and y down to next multiple of four; width and height up to next multiple of four
-            int roundedWidth = (rect.Width + 3) & ~0x3;
-            int roundedHeight = (rect.Height + 3) & ~0x3;
-            checkedRect = new Rectangle(rect.X & ~0x3, rect.Y & ~0x3,
-#if OPENGL
-                    // OpenGL only: The last two mip levels require the width and height to be
-                    // passed as 2x2 and 1x1, but there needs to be enough data passed to occupy
-                    // a 4x4 block.
-                    (rect.Width < 4 && textureBounds.Width < 4) ? textureBounds.Width : roundedWidth,
-                    (rect.Height < 4 && textureBounds.Height < 4) ? textureBounds.Height : roundedHeight);
-#else
-                                        roundedWidth, roundedHeight);
-#endif
-            return (roundedWidth * roundedHeight * fSize / 16);
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (rect.Width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (rect.Height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRect = new Rectangle(rect.X & ~blockWidthMinusOne, rect.Y & ~blockHeightMinusOne,
+                                        (rect.Width < blockWidth && textureBounds.Width < blockWidth) ? textureBounds.Width : roundedWidth,
+                                        (rect.Height < blockHeight && textureBounds.Height < blockHeight) ? textureBounds.Height : roundedHeight);
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRect.Width, 16) * Math.Max(checkedRect.Height, 8) * 2 + 7) / 8;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRect.Width, 8) * Math.Max(checkedRect.Height, 8) * 4 + 7) / 8;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight);
+            }
         }
         #endregion ITextureCubeStrategy
 

--- a/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
@@ -51,7 +51,10 @@ namespace Microsoft.Xna.Platform.Graphics
                 WebGLTextureTarget target = ConcreteTextureCube.GetGLCubeFace(face);
                 if (_glIsCompressedTexture)
                 {
-                    throw new NotImplementedException();
+                    GL.CompressedTexSubImage2D(
+                        target, level, checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height,
+                        _glFormat, data, startIndex, elementCount);
+                    GL.CheckGLError();
                 }
                 else
                 {

--- a/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
@@ -42,9 +42,6 @@ namespace Microsoft.Xna.Platform.Graphics
             {
                 var GL = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy.ToConcrete<ConcreteGraphicsContext>().GL;
 
-                if (startIndex != 0 && !_glIsCompressedTexture)
-                    throw new NotImplementedException("startIndex");
-
                 ((IPlatformTextureCollection)base.GraphicsDeviceStrategy.CurrentContext.Textures).Strategy.Dirty(0);
                 GL.ActiveTexture(WebGLTextureUnit.TEXTURE0 + 0);
                 GL.CheckGLError();
@@ -58,7 +55,8 @@ namespace Microsoft.Xna.Platform.Graphics
                 }
                 else
                 {
-                    GL.TexSubImage2D(target, level, checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height, _glFormat, _glType, data);
+                    GL.TexSubImage2D(target, level, checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height,
+                        _glFormat, _glType, data, startIndex, elementCount);
                     GL.CheckGLError();
                 }
             }

--- a/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
@@ -159,7 +159,7 @@ namespace Microsoft.Xna.Platform.Graphics
                 ConcreteTexture.ToGLSurfaceFormat(format, contextStrategy,
                     out _glInternalFormat,
                     out _glFormat,
-                    out _glType, 
+                    out _glType,
                     out _glIsCompressedTexture
                     );
 
@@ -168,21 +168,30 @@ namespace Microsoft.Xna.Platform.Graphics
                 {
                     WebGLTextureTarget target = ConcreteTextureCube.GetGLCubeFace((CubeMapFace)i);
 
-                    if (_glIsCompressedTexture)
+                    int s = size;
+                    int level = 0;
+                    while (true)
                     {
-                         throw new NotImplementedException();
-                    }
-                    else
-                    {
-                        GL.TexImage2D(target, 0, _glInternalFormat, size, size, _glFormat, _glType);
-                        GL.CheckGLError();
-                    }
-                }
+                        if (_glIsCompressedTexture)
+                        {
+                            Rectangle bounds = new Rectangle(0, 0, s, s);
+                            int dataSize = GetCompressedDataByteSize(format.GetSize(), bounds, ref bounds, out Rectangle checkedRect);
+                            byte[] data = new byte[dataSize]; // WebGL CompressedTexImage2D requires data.
+                            GL.CompressedTexImage2D(target, level, _glInternalFormat, checkedRect.Width, checkedRect.Height, data);
+                            GL.CheckGLError();
+                        }
+                        else
+                        {
+                            GL.TexImage2D(target, level, _glInternalFormat, s, s, _glFormat, _glType);
+                            GL.CheckGLError();
+                        }
 
-                if (mipMap)
-                {
-                    GL.GenerateMipmap(WebGLTextureTarget.TEXTURE_CUBE_MAP);
-                    GL.CheckGLError();
+                        if ((s == 1) || !mipMap)
+                            break;
+                        if (s > 1)
+                            s = s / 2;
+                        ++level;
+                    }
                 }
             }
         }

--- a/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTextureCube.cs
@@ -68,7 +68,25 @@ namespace Microsoft.Xna.Platform.Graphics
         public void GetData<T>(CubeMapFace face, int level, Rectangle checkedRect, T[] data, int startIndex, int elementCount)
             where T : struct
         {
-            throw new NotImplementedException();
+            GraphicsContextStrategy contextStrategy = ((IPlatformGraphicsContext)base.GraphicsDeviceStrategy.CurrentContext).Strategy;
+            var GL = contextStrategy.ToConcrete<ConcreteGraphicsContext>().GL;
+
+            ValidateGetDataSurfaceFormat(Format, contextStrategy);
+
+            WebGLTextureTarget target = ConcreteTextureCube.GetGLCubeFace(face);
+
+            WebGLFramebuffer glFramebuffer;
+            glFramebuffer = GL.CreateFramebuffer();
+            GL.CheckGLError();
+            GL.BindFramebuffer(WebGLFramebufferType.FRAMEBUFFER, glFramebuffer);
+            GL.CheckGLError();
+            GL.FramebufferTexture2D(
+                WebGLFramebufferType.FRAMEBUFFER, WebGLFramebufferAttachmentPoint.COLOR_ATTACHMENT0, target, _glTexture, level);
+            GL.CheckGLError();
+
+            GL.ReadPixels(checkedRect.X, checkedRect.Y, checkedRect.Width, checkedRect.Height, _glFormat, _glType, data);
+            GL.CheckGLError();
+            glFramebuffer.Dispose();
         }
 
         public int GetCompressedDataByteSize(int fSize, Rectangle rect, ref Rectangle textureBounds, out Rectangle checkedRect)

--- a/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.DX11/ConcreteTexture3D.cs
@@ -146,6 +146,29 @@ namespace Microsoft.Xna.Platform.Graphics
             }
 
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            checkedRight = checkedLeft + roundedWidth;
+            checkedBottom = checkedTop + roundedHeight;
+            checkedFront = front;
+            checkedBack = back;
+            return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+        }
         #endregion ITexture3DStrategy
 
         internal void PlatformConstructTexture3D(GraphicsContextStrategy contextStrategy, int width, int height, int depth, bool mipMap, SurfaceFormat format)

--- a/Platforms/Graphics/.GL/ConcreteTexture.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture.cs
@@ -350,6 +350,49 @@ namespace Microsoft.Xna.Platform.Graphics
             }
         }
 
+        internal static void ValidateGetDataSurfaceFormat(SurfaceFormat format, GraphicsContextStrategy contextStrategy)
+        {
+#if GLES
+            bool isGLES3 = ((ConcreteGraphicsContextGL)contextStrategy)._glVersion.Major >= 3;
+
+            bool valid;
+            switch (format)
+            {
+                case SurfaceFormat.Color:
+                case SurfaceFormat.Bgr565:
+                case SurfaceFormat.Bgra5551:
+                case SurfaceFormat.Bgra4444:
+                case SurfaceFormat.Alpha8:
+                    valid = true;
+                    break;
+
+                case SurfaceFormat.NormalizedByte2:
+                case SurfaceFormat.NormalizedByte4:
+                case SurfaceFormat.Rgba1010102:
+                case SurfaceFormat.Rg32:
+                case SurfaceFormat.Rgba64:
+                case SurfaceFormat.Single:
+                case SurfaceFormat.Vector2:
+                case SurfaceFormat.Vector4:
+                case SurfaceFormat.HalfSingle:
+                case SurfaceFormat.HalfVector2:
+                case SurfaceFormat.HalfVector4:
+                case SurfaceFormat.HdrBlendable:
+                case SurfaceFormat.ColorSRgb:
+                case SurfaceFormat.ColorSRgba:
+                    valid = isGLES3;
+                    break;
+
+                default:
+                    valid = false;
+                    break;
+            }
+
+            if (!valid)
+                throw new NotSupportedException($"GetData is not supported with SurfaceFormat.{format} on this platform.");
+#endif
+        }
+
         internal static void PlatformCreateRenderTarget(IRenderTargetStrategyGL renderTargetGL, GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat preferredFormat, DepthFormat preferredDepthFormat, int multiSampleCount)
         {
             bool isSharedContext = contextStrategy.ToConcrete<ConcreteGraphicsContextGL>().BindSharedContext();

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -91,6 +91,42 @@ namespace Microsoft.Xna.Platform.Graphics
         {
             throw new NotImplementedException();
         }
+
+        public int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+                                             int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+                                             out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                             out int checkedFront, out int checkedBack)
+        {
+            int width = right - left;
+            int height = bottom - top;
+            int depth = back - front;
+            Format.GetBlockSize(out int blockWidth, out int blockHeight);
+            int blockWidthMinusOne = blockWidth - 1;
+            int blockHeightMinusOne = blockHeight - 1;
+            // round x and y down to next multiple of block size; width and height up to next multiple of block size
+            int roundedWidth = (width + blockWidthMinusOne) & ~blockWidthMinusOne;
+            int roundedHeight = (height + blockHeightMinusOne) & ~blockHeightMinusOne;
+            checkedLeft = left & ~blockWidthMinusOne;
+            checkedTop = top & ~blockHeightMinusOne;
+            // The last two mip levels require the width and height to be passed
+            // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
+            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
+            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedFront = front;
+            checkedBack = back;
+            if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 16) * Math.Max(checkedBottom - checkedTop, 8) * 2 + 7) / 8 * depth;
+            }
+            else if (Format == SurfaceFormat.RgbPvrtc4Bpp || Format == SurfaceFormat.RgbaPvrtc4Bpp)
+            {
+                return (Math.Max(checkedRight - checkedLeft, 8) * Math.Max(checkedBottom - checkedTop, 8) * 4 + 7) / 8 * depth;
+            }
+            else
+            {
+                return roundedWidth * roundedHeight * fSize / (blockWidth * blockHeight) * depth;
+            }
+        }
         #endregion ITexture3DStrategy
 
 

--- a/Platforms/Graphics/.GL/ConcreteTexture3D.cs
+++ b/Platforms/Graphics/.GL/ConcreteTexture3D.cs
@@ -110,8 +110,8 @@ namespace Microsoft.Xna.Platform.Graphics
             checkedTop = top & ~blockHeightMinusOne;
             // The last two mip levels require the width and height to be passed
             // as 2x2 and 1x1, but there needs to be enough data passed to occupy a full block.
-            checkedRight = checkedLeft + ((width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : roundedWidth);
-            checkedBottom = checkedTop + ((height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : roundedHeight);
+            checkedRight = (width < blockWidth && textureBoundsWidth < blockWidth) ? textureBoundsWidth : checkedLeft + roundedWidth;
+            checkedBottom = (height < blockHeight && textureBoundsHeight < blockHeight) ? textureBoundsHeight : checkedTop + roundedHeight;
             checkedFront = front;
             checkedBack = back;
             if (Format == SurfaceFormat.RgbPvrtc2Bpp || Format == SurfaceFormat.RgbaPvrtc2Bpp)

--- a/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/ITexture3DStrategy.cs
@@ -17,5 +17,8 @@ namespace Microsoft.Xna.Platform.Graphics
 
         void SetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
         void GetData<T>(int level, int left, int top, int right, int bottom, int front, int back, T[] data, int startIndex, int elementCount) where T : struct;
+        int GetCompressedDataByteSize(int fSize, int left, int top, int right, int bottom, int front, int back,
+            int textureBoundsWidth, int textureBoundsHeight, int textureBoundsDepth,
+            out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom, out int checkedFront, out int checkedBack);
     }
 }

--- a/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
+++ b/src/Xna.Framework.Graphics/Graphics/Texture3D.cs
@@ -60,7 +60,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -68,7 +70,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.SetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -77,8 +81,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);
-            _strategyTexture3D.SetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.SetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -100,8 +107,11 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount);                       
-            _strategyTexture3D.GetData<T>(level, left, top, right, bottom, front, back, data, startIndex, elementCount);
+            ValidateParams<T>(level, left, top, right, bottom, front, back, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
+            _strategyTexture3D.GetData<T>(level, checkedLeft, checkedTop, checkedRight, checkedBottom, checkedFront, checkedBack,
+                                          data, startIndex, elementCount);
         }
 
         /// <summary>
@@ -115,7 +125,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, startIndex, elementCount);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, elementCount,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, startIndex, elementCount);
         }
 
@@ -128,7 +140,9 @@ namespace Microsoft.Xna.Framework.Graphics
             where T : struct
         {
             ValidateArrayBounds<T>(data, 0, data.Length);
-            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length);
+            ValidateParams<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data.Length,
+                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                              out int checkedFront, out int checkedBack);
             _strategyTexture3D.GetData<T>(0, 0, 0, this.Width, this.Height, 0, this.Depth, data, 0, data.Length);
         }
 
@@ -143,9 +157,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 throw new ArgumentException("The data array is too small.");
         }
 
-        private unsafe void ValidateParams<T>(int level,
-                                       int left, int top, int right, int bottom, int front, int back,
-                                       int elementCount)
+        private unsafe void ValidateParams<T>(int level, int left, int top, int right, int bottom, int front, int back, int elementCount,
+                                              out int checkedLeft, out int checkedTop, out int checkedRight, out int checkedBottom,
+                                              out int checkedFront, out int checkedBack)
             where T : struct
         {
             int tSize = sizeof(T);
@@ -168,7 +182,24 @@ namespace Microsoft.Xna.Framework.Graphics
             if (level < 0 || level >= LevelCount)
                 throw new ArgumentException("level must be smaller than the number of levels in this texture.");
 
-            int dataByteSize = width*height*depth*fSize;
+            int dataByteSize;
+            if (Format.IsCompressedFormat())
+            {
+                dataByteSize = _strategyTexture3D.GetCompressedDataByteSize(
+                    fSize, left, top, right, bottom, front, back, texWidth, texHeight, texDepth,
+                    out checkedLeft, out checkedTop, out checkedRight, out checkedBottom, out checkedFront, out checkedBack);
+            }
+            else
+            {
+                checkedLeft = left;
+                checkedTop = top;
+                checkedRight = right;
+                checkedBottom = bottom;
+                checkedFront = front;
+                checkedBack = back;
+                dataByteSize = width * height * depth * fSize;
+            }
+
             if (elementCount * tSize != dataByteSize)
                 throw new ArgumentException(string.Format("elementCount is not the right size, " +
                                             "elementCount * sizeof(T) is {0}, but data size is {1}.",
@@ -176,4 +207,3 @@ namespace Microsoft.Xna.Framework.Graphics
         }
     }
 }
-


### PR DESCRIPTION
TextureCube fixes/implementations for BlazorGL.

Implements:
- Mipmap support.
- Compressed `SurfaceFormat` support.
- `SetData` with startIndex argument.
- `GetData` support.
 
Fixes:
- Removes incorrect "OpenGL only" code as it relates to WebGL too.
- Missing `GetCompressedDataByteSize` format calculations (now matches `Texture2D` version).

This PR is dependent on the following PRs:
- https://github.com/kniEngine/kni/pull/2636
- https://github.com/kniEngine/kni/pull/2635
- https://github.com/nkast/Wasm/pull/27
- https://github.com/nkast/Wasm/pull/29

Test project: https://github.com/squarebananas/XnaApiTesting

In order to run the test project, the following workaround is needed for `ConcreteShader.CreateShader`:
`glslCode = glslCode.Replace("precision highp float;", "precision highp float;\nprecision highp sampler3D;");`