### PR TITLE
Fixes RenderTargetCube with DepthFormat.None for BlazorGL

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteRenderTargetCube.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteRenderTargetCube.cs
@@ -34,7 +34,9 @@ namespace Microsoft.Xna.Platform.Graphics
 
             PlatformConstructTextureCube_rt(contextStrategy, size, mipMap, preferredSurfaceFormat);
 
-            PlatformConstructRenderTargetCube(contextStrategy, mipMap, preferredDepthFormat, _multiSampleCount);
+            // If we don't need a depth buffer then we're done.
+            if (preferredDepthFormat != DepthFormat.None)
+                PlatformConstructRenderTargetCube(contextStrategy, mipMap, preferredDepthFormat, _multiSampleCount);
         }
 
 


### PR DESCRIPTION
Fixes creating a `RenderTargetCube` with `DepthFormat.None` on BlazorGL.

This check to skip creating an unimplemented depth buffer matches the current `Texture3D` code.

Test project: https://github.com/squarebananas/XnaApiTesting

In order to run the test project, the following workaround is needed for `ConcreteShader.CreateShader`:
`glslCode = glslCode.Replace("precision highp float;", "precision highp float;\nprecision highp sampler3D;");`