### PR TITLE
Touch input for SDL2

### DIFF
--- a/Platforms/Game/.SDL2/SDLGameWindow.cs
+++ b/Platforms/Game/.SDL2/SDLGameWindow.cs
@@ -297,9 +297,7 @@ namespace Microsoft.Xna.Framework
                             float x = ev.Finger.X;
                             float y = ev.Finger.Y;
                             x *= _width; y *= _height;
-#if ENABLE_TOUCHINPUT
                             ((IPlatformTouchPanel)TouchPanel.Current).GetStrategy<ConcreteTouchPanel>().AddPressedEvent(identifier, new Vector2(x, y));
-#endif
                         }
                         break;
                     case Sdl.EventType.FingerMotion:
@@ -308,9 +306,7 @@ namespace Microsoft.Xna.Framework
                             float x = ev.Finger.X;
                             float y = ev.Finger.Y;
                             x *= _width; y *= _height;
-#if ENABLE_TOUCHINPUT
                             ((IPlatformTouchPanel)TouchPanel.Current).GetStrategy<ConcreteTouchPanel>().AddMovedEvent(identifier, new Vector2(x, y));
-#endif
                         }
                         break;
                     case Sdl.EventType.FingerUp:
@@ -319,9 +315,7 @@ namespace Microsoft.Xna.Framework
                             float x = ev.Finger.X;
                             float y = ev.Finger.Y;
                             x *= _width; y *= _height;
-#if ENABLE_TOUCHINPUT
                             ((IPlatformTouchPanel)TouchPanel.Current).GetStrategy<ConcreteTouchPanel>().AddReleasedEvent(identifier, new Vector2(x, y));
-#endif
                         }
                         break;
 

--- a/Platforms/Input/.SDL2/ConcreteMouse.cs
+++ b/Platforms/Input/.SDL2/ConcreteMouse.cs
@@ -48,30 +48,9 @@ namespace Microsoft.Xna.Platform.Input
 
                 int winFlags = SDL.WINDOW.GetWindowFlags(wndHandle);
 
-                switch (gameWindow._sysWMType)
-                {
-                    case Sdl.Window.SysWMType.Wayland:
-                        {
-                            if (SDL.SDLInitThreadId == SDL.GetManagedThreadId())
-                                SDL.PumpEvents();
-                            state = SDL.MOUSE.GetState(out mousePos.X, out mousePos.Y);
-                        }
-                        break;
-                    default:
-                        {
-#if ENABLE_TOUCHINPUT
-                            if (SDL.SDLInitThreadId == SDL.GetManagedThreadId())
-                                SDL.PumpEvents();
-                            state = SDL.MOUSE.GetState(out mousePos.X, out mousePos.Y);
-#else
-                            Point globalPos, windowPos;
-                            state = SDL.MOUSE.GetGlobalState(out globalPos.X, out globalPos.Y);
-                            SDL.WINDOW.GetPosition(wndHandle, out windowPos.X, out windowPos.Y);
-                            mousePos = globalPos - windowPos;
-#endif
-                        }
-                        break;
-                }
+                if (SDL.SDLInitThreadId == SDL.GetManagedThreadId())
+                    SDL.PumpEvents();
+                state = SDL.MOUSE.GetState(out mousePos.X, out mousePos.Y);
             }
             else // (wndHandle == IntPtr.Zero)
             {


### PR DESCRIPTION
This implements Touch input for the SDL2 backend.

In order to prevent Touches to appear as Mouse input, we now use [SDL_GetMouseState](https://wiki.libsdl.org/SDL2/SDL_GetMouseState) instead of https://wiki.libsdl.org/SDL2/SDL_GetGlobalMouseState, which change the behavior of Mouse.GetState().

- Mouse input doesn't escape the Window bounds. This makes windowed mode behave more like a fullscreen mode. This is also how touch input is implemented in this PR and on the WinForms backend. Touch outside the window are released.
- We lost the ability to query up to date mouse position, because GetMouseState is updated during the event pump.
- docs report that GetGlobalMouseState was less efficient.
- The change could fix a reported bug on linux/hyprland.


related to #2619
closes #2603
resolves #2562