### PR TITLE
fix SDL2 PumpEvents signature.

### DIFF
--- a/Platforms/Game/.SDL2/SDL2.cs
+++ b/Platforms/Game/.SDL2/SDL2.cs
@@ -269,7 +269,7 @@ internal class Sdl
     public d_sdl_pollevent PollEvent;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-    public delegate int d_sdl_pumpevents();
+    public delegate void d_sdl_pumpevents();
     public d_sdl_pumpevents PumpEvents;
 
     [UnmanagedFunctionPointer(CallingConvention.Cdecl)]


### PR DESCRIPTION
[SDL_PumpEvents()](https://wiki.libsdl.org/SDL2/SDL_PumpEvents) doesn't return.