### PR TITLE
catch Malformed wav files

### DIFF
--- a/Platforms/Audio/OpenAL/AudioLoader.cs
+++ b/Platforms/Audio/OpenAL/AudioLoader.cs
@@ -112,6 +112,9 @@ namespace Microsoft.Xna.Platform.Audio
                                     if (cbSize > 0)
                                         SkipBytes(reader, cbSize);
                                 }
+
+                                if (reader.BaseStream.Position < nextChunk)
+                                    throw new InvalidDataException("Unknown WAV fmt chunk format.");
                             }
                             break;
 


### PR DESCRIPTION
This catches malformed wav files early, instead of going through bad data until an EndOfStreamException is thrown. We could skip ahead to the next chunk, and ignore the additional data, but we can't assume now that this isn't a new fmt extension.