### PR TITLE
Implement Texture2D.GetSharedHandle() for BlazorGL

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture2D.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Xna.Platform.Graphics
             if (this._shared)
                 return new IntPtr(this._glTexture.Uid);
 
-            throw new InvalidOperationException();
+            throw new InvalidOperationException("GetSharedHandle() requires the Texture2D to have been created with shared=true.");
         }
 
         public void SetData<T>(int level, T[] data, int startIndex, int elementCount)

--- a/Platforms/Graphics/.BlazorGL/ConcreteTexture2D.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteTexture2D.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Xna.Platform.Graphics
         private readonly int _height;
         private readonly int _arraySize;
 
+        protected readonly bool _shared;
+
 
         internal ConcreteTexture2D(GraphicsContextStrategy contextStrategy, int width, int height, bool mipMap, SurfaceFormat format, int arraySize, bool shared,
                                    bool isRenderTarget)
@@ -24,6 +26,8 @@ namespace Microsoft.Xna.Platform.Graphics
             this._width  = width;
             this._height = height;
             this._arraySize = arraySize;
+
+            this._shared = shared;
 
             System.Diagnostics.Debug.Assert(isRenderTarget);
         }
@@ -34,6 +38,8 @@ namespace Microsoft.Xna.Platform.Graphics
             this._width  = width;
             this._height = height;
             this._arraySize = arraySize;
+
+            this._shared = shared;
 
             this.PlatformConstructTexture2D(contextStrategy, width, height, mipMap, format, shared);
         }
@@ -51,7 +57,10 @@ namespace Microsoft.Xna.Platform.Graphics
 
         public IntPtr GetSharedHandle()
         {
-            throw new NotImplementedException();
+            if (this._shared)
+                return new IntPtr(this._glTexture.Uid);
+
+            throw new InvalidOperationException();
         }
 
         public void SetData<T>(int level, T[] data, int startIndex, int elementCount)


### PR DESCRIPTION
## Summary

`ITexture2DStrategy.GetSharedHandle()` is implemented for GL, DX11, and Ref, but BlazorGL's `ConcreteTexture2D.GetSharedHandle()` throws `NotImplementedException`. This fills it in, mirroring the GL platform's shape:

- Store the `shared` constructor flag (previously accepted but discarded in both constructors / `PlatformConstructTexture2D`).
- Return `new IntPtr(_glTexture.Uid)` when the texture was created shared, matching `nkast.Wasm.Canvas.WebGL.WebGLTexture.Uid` (already public).
- Throw `InvalidOperationException` otherwise — same behavior as the GL platform.

## Motivation

Building a Skia-into-KNI-texture GPU interop layer for WebGL (compositing SkiaSharp canvas output into a KNI-owned texture via `gl.texImage2D`) and need a supported way to get the native `WebGLTexture` handle off a shared `Texture2D`, instead of reflecting into the private `_glTexture` field.

Fixes #2668

## Test plan

- [x] `dotnet build Platforms/Kni.Platform.Blazor.GL.csproj -c Release` — 0 errors, only pre-existing warnings.
- [ ] Exercised against a real shared-texture WebGL consumer (in progress downstream).