### PR TITLE
Implement VideoPlayer for SDL2

### DIFF
--- a/Platforms/Kni.Platform.SDL2.GL.csproj
+++ b/Platforms/Kni.Platform.SDL2.GL.csproj
@@ -182,6 +182,11 @@
     <Compile Include="Media\DesktopGL\ConcreteSong.cs" />
     <Compile Include="Media\DesktopGL\ConcreteVideoPlayer.cs" />
     <Compile Include="Media\DesktopGL\ConcreteVideo.cs" />
+    <Compile Include="Media\DesktopGL\VideoDecoder\DecoderThread.cs" />
+    <Compile Include="Media\DesktopGL\VideoDecoder\FrameBufferPool.cs" />
+    <Compile Include="Media\DesktopGL\VideoDecoder\PipeBinaryReader.cs" />
+    <Compile Include="Media\DesktopGL\VideoDecoder\TrackData.cs" />
+    <Compile Include="Media\DesktopGL\VideoDecoder\VideoDecoderProcess.cs" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net40' ">

--- a/Platforms/Media/DesktopGL/ConcreteVideoPlayer.cs
+++ b/Platforms/Media/DesktopGL/ConcreteVideoPlayer.cs
@@ -3,7 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading;
+using System.Linq;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
@@ -14,9 +14,13 @@ namespace Microsoft.Xna.Platform.Media
 {
     internal sealed class ConcreteVideoPlayerStrategy : VideoPlayerStrategy
     {
-        private Texture2D _lastFrame;
+        private Texture2D[] _textures = new Texture2D[2];
+        private int _currentTexture;
+        private TimeSpan _lastFrameTime;
 
-        private DynamicSoundEffectInstance _soundPlayer;
+        internal DynamicSoundEffectInstance _soundPlayer;
+
+        DecoderThread _decoderThread;
 
         public override MediaState State
         {
@@ -42,7 +46,7 @@ namespace Microsoft.Xna.Platform.Media
 
         public override TimeSpan PlayPosition
         {
-            get { throw new NotImplementedException(); }
+            get { return _decoderThread.Watch.Elapsed; }
         }
 
         public override float Volume
@@ -62,18 +66,35 @@ namespace Microsoft.Xna.Platform.Media
 
         public override Texture2D PlatformGetTexture()
         {
-            if (_lastFrame != null)
+            if (_textures[0] != null)
             {
-                if (_lastFrame.Width != base.Video.Width || _lastFrame.Height != base.Video.Height)
+                if (_textures[0].Width != base.Video.Width || _textures[0].Height != base.Video.Height)
                 {
-                    _lastFrame.Dispose();
-                    _lastFrame = null;
+                    _textures[0].Dispose();
+                    _textures[0] = null;
+                    _textures[1].Dispose();
+                    _textures[1] = null;
                 }
             }
-            if (_lastFrame == null)
-                _lastFrame = new Texture2D(((IPlatformVideo)base.Video).Strategy.GraphicsDevice, base.Video.Width, base.Video.Height, false, SurfaceFormat.Color);
+            if (_textures[0] == null)
+            {
+                GraphicsDevice graphicsDevice = ((IPlatformVideo)base.Video).Strategy.GraphicsDevice;
+                _textures[0] = new Texture2D(graphicsDevice, base.Video.Width, base.Video.Height, false, SurfaceFormat.Color);
+                _textures[1] = new Texture2D(graphicsDevice, base.Video.Width, base.Video.Height, false, SurfaceFormat.Color);
+            }
 
-            throw new NotImplementedException();
+            if (_decoderThread != null)
+            {
+                if (_decoderThread.TryGetNextVideoFrame(out TrackData frameData))
+                {
+                    _lastFrameTime = frameData.TrackTime;
+                    _currentTexture = (_currentTexture+1) & 0x01;
+                    _textures[_currentTexture].SetData(frameData.Data);
+                    _decoderThread._videoFramePool.Return(frameData.Data);
+                }
+            }
+
+            return _textures[_currentTexture];
         }
 
         protected override void PlatformUpdateState(ref MediaState state)
@@ -85,45 +106,134 @@ namespace Microsoft.Xna.Platform.Media
         {
             base.Video = video;
 
-            throw new NotImplementedException();
+            // Cleanup the last video first.
+            if (State != MediaState.Stopped)
+            {
+                _decoderThread.Stop();
+                _decoderThread.Stopped -= OnDecoderThreadStopped;
+                _decoderThread = null;
+                if (_soundPlayer != null)
+                    _soundPlayer.Dispose();
+                _soundPlayer = null;
+            }
+
+            _decoderThread = new DecoderThread(this);
+            _decoderThread.Stopped += OnDecoderThreadStopped;
+
+            VideoDecoderProcess.MKVTrack vtrack = _decoderThread.DecoderProcess._tracks.Values.First((t) => (t.Type == VideoDecoderProcess.MKVTrackType.Video));
+            VideoDecoderProcess.MKVVideoTrack videoTrack = (VideoDecoderProcess.MKVVideoTrack)vtrack;
+            VideoDecoderProcess.MKVVideoSettings videoSettings = videoTrack.VideoSettings;
+
+            VideoDecoderProcess.MKVTrack atrack = _decoderThread.DecoderProcess._tracks.Values.FirstOrDefault((t) => (t.Type == VideoDecoderProcess.MKVTrackType.Audio));
+            if (atrack != null)
+            {
+                VideoDecoderProcess.MKVAudioTrack audioTrack = (VideoDecoderProcess.MKVAudioTrack)atrack;
+                VideoDecoderProcess.MKVAudioSettings audioSettings = audioTrack.AudioSettings;
+                int SampleRate = (int)audioSettings.SamplingFrequency;
+                AudioChannels channels = (AudioChannels)audioSettings.Channels;
+                int samples = (SampleRate * (int)channels) / 2;
+                _soundPlayer = new DynamicSoundEffectInstance(SampleRate, channels);
+
+                _soundPlayer.BufferNeeded += (s, e) =>
+                {
+                    Debug.WriteLine("_soundPlayer.PendingBufferCount: " + _soundPlayer.PendingBufferCount);
+                    Debug.WriteLine("_videoFrameQueue.Count: " + _decoderThread._videoFrameQueue.Count);
+                };
+            }
+            PlatformSetVolume();
+            if (_soundPlayer != null)
+                _soundPlayer.Play();
+
+            _lastFrameTime = TimeSpan.Zero;
+            this.State = MediaState.Playing;
+
+            _decoderThread.Start();
         }
 
         public override void PlatformPause()
         {
-            throw new NotImplementedException();
+            _decoderThread.Watch.Stop();
+            if (_soundPlayer!=null)
+                _soundPlayer.Pause();
+            State = MediaState.Paused;
         }
 
         public override void PlatformResume()
         {
-            throw new NotImplementedException();
+            if (_soundPlayer != null)
+                _soundPlayer.Resume();
+            _decoderThread.Watch.Start();
+            State = MediaState.Playing;
         }
 
         public override void PlatformStop()
         {
+            if (_decoderThread != null)
+            {
+                _decoderThread.Stop();
+                _decoderThread.Stopped -= OnDecoderThreadStopped;
+                _decoderThread = null;
+            }
 
-            throw new NotImplementedException();
+            State = MediaState.Stopped;
+            if (_soundPlayer != null)
+            {
+                _soundPlayer.Stop();
+                _soundPlayer.Dispose();
+                _soundPlayer = null;
+            }
+        }
+
+        private void OnDecoderThreadStopped(object sender, EventArgs e)
+        {
+            // TODO: event comes from another thread, so we need to sync base.State, and clean up. 
+            base.State = MediaState.Stopped;
+
+            _decoderThread.Stopped -= OnDecoderThreadStopped;
+            _decoderThread = null;
+            if (_soundPlayer != null)
+                _soundPlayer.Dispose();
+            _soundPlayer = null;
         }
 
         private void PlatformSetVolume()
         {
-           float volume = base.Volume;
-           if (IsMuted)
+            float volume = base.Volume;
+            if (IsMuted)
                 volume = 0.0f;
 
-           if (_soundPlayer != null)
-              _soundPlayer.Volume = volume;
+            if (_soundPlayer != null)
+                _soundPlayer.Volume = volume;
         }
 
         protected override void Dispose(bool disposing)
         {
             if (disposing)
             {
+                if (_decoderThread != null)
+                {
+                    _decoderThread.Stop();
+                    _decoderThread.Stopped -= OnDecoderThreadStopped;
+                    _decoderThread = null;
+                }
                 if (_soundPlayer != null)
                 {
                     _soundPlayer.Dispose();
                     _soundPlayer = null;
                 }
+                if (_textures != null)
+                {
+                    if (_textures[0] != null)
+                        _textures[0].Dispose();
+                    if (_textures[1] != null)
+                        _textures[1].Dispose();
+                    _textures[0] = null;
+                    _textures[1] = null;
+                    _textures = null;
+                }
+
             }
+
 
             base.Dispose(disposing);
         }

--- a/Platforms/Media/DesktopGL/VideoDecoder/DecoderThread.cs
+++ b/Platforms/Media/DesktopGL/VideoDecoder/DecoderThread.cs
@@ -1,0 +1,244 @@
+﻿// Copyright (C)2025 Nick Kastellanos
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using Microsoft.Xna.Framework.Media;
+using Microsoft.Xna.Platform.Audio;
+
+namespace Microsoft.Xna.Platform.Media
+{
+    internal enum ThreadState
+    {
+        None,
+        Playing,
+        Stop,
+        Suspend,
+    }
+
+    internal class DecoderThread
+    {
+        private readonly ConcreteVideoPlayerStrategy VideoPlayerStrategy;
+        public VideoDecoderProcess DecoderProcess;
+        internal readonly Stopwatch Watch = new Stopwatch();
+        private volatile ThreadState _threadState;
+
+        internal Queue<TrackData> _videoFrameQueue = new Queue<TrackData>();
+        internal Queue<TrackData> _audioFrameQueue = new Queue<TrackData>();
+        internal FrameBufferPool _videoFramePool = new FrameBufferPool();
+        internal FrameBufferPool _audioFramePool = new FrameBufferPool();
+
+        private TrackData? _nextVideoFrame;
+        private object _nextVideoFrameLock = new object();
+        private int _currentLoopCount = 0;
+        private int _prevLoopCount = 0;
+
+        internal Thread _thread;
+
+        public event EventHandler Stopped;
+
+        public DecoderThread(ConcreteVideoPlayerStrategy videoPlayerStrategy)
+        {
+            this.VideoPlayerStrategy = videoPlayerStrategy;
+            this._threadState = ThreadState.None;
+
+            string ffmpegPath = GetFFmpegPath();
+            string inputFile = "" + ((IPlatformVideo)VideoPlayerStrategy.Video).Strategy.FileName;
+            this.DecoderProcess = new VideoDecoderProcess(VideoPlayerStrategy.Video, ffmpegPath, inputFile);
+
+            _thread = new Thread(DecoderThread.OnThreadStart);
+            _thread.IsBackground = true;
+
+            DecoderProcess.ParseMKV(_videoFrameQueue, _audioFrameQueue, _videoFramePool, _audioFramePool, _currentLoopCount);
+        }
+
+        public void Start()
+        {
+            this._threadState = ThreadState.Playing;
+            _thread.Start(this);
+
+            Watch.Reset();
+            Watch.Start();
+        }
+
+        private static void OnThreadStart(object obj)
+        {
+            DecoderThread decoderThread = (DecoderThread)obj;
+            ConcreteVideoPlayerStrategy videoPlayerStrategy = decoderThread.VideoPlayerStrategy;
+
+            bool reachEndOfStream = false;
+            while (true)
+            {
+                if (decoderThread._threadState == ThreadState.Stop)
+                    break;
+
+                if (decoderThread._videoFrameQueue.Count < 1
+                ||  decoderThread._audioFrameQueue.Count < 1)
+                {
+                    try
+                    {
+                        decoderThread.DecoderProcess.ParseSegmentCluster2(decoderThread.DecoderProcess._binaryReader, (long)0,
+                                                                          decoderThread._videoFrameQueue, decoderThread._audioFrameQueue,
+                                                                          decoderThread._videoFramePool, decoderThread._audioFramePool, 
+                                                                          decoderThread._currentLoopCount);
+                    }
+                    catch (EndOfStreamException eosEx)
+                    {
+                        if (videoPlayerStrategy.IsLooped)
+                        {
+                            decoderThread._currentLoopCount++;
+
+                            decoderThread.DecoderProcess.Dispose();
+                            decoderThread.DecoderProcess = null;
+
+                            string ffmpegPath = GetFFmpegPath();
+                            string inputFile = "" + ((IPlatformVideo)videoPlayerStrategy.Video).Strategy.FileName;
+                            decoderThread.DecoderProcess = new VideoDecoderProcess(videoPlayerStrategy.Video, ffmpegPath, inputFile);
+
+                            decoderThread.DecoderProcess.ParseMKV(decoderThread._videoFrameQueue, decoderThread._audioFrameQueue,
+                                                                  decoderThread._videoFramePool, decoderThread._audioFramePool,
+                                                                  decoderThread._currentLoopCount);
+                        }
+                        else
+                        {
+                            reachEndOfStream = true;
+                        }
+                    }
+                }
+
+                lock (AudioService.SyncHandle)
+                {
+                    if (videoPlayerStrategy._soundPlayer != null)
+                    {
+                        ConcreteDynamicSoundEffectInstance cdsei = ((IPlatformSoundEffectInstance)videoPlayerStrategy._soundPlayer)
+                            .GetStrategy<ConcreteDynamicSoundEffectInstance>();
+                        cdsei.DynamicPlatformUpdateBuffers();
+                    }
+                }
+
+                while (decoderThread.TryPeekAudioFrame(out TrackData audioFrame)
+                   && videoPlayerStrategy._soundPlayer.PendingBufferCount <= 3)
+                {
+                    decoderThread._audioFrameQueue.Dequeue();
+                    videoPlayerStrategy._soundPlayer.SubmitBuffer(audioFrame.Data, 0, audioFrame.Data.Length);
+                    decoderThread._audioFramePool.Return(audioFrame.Data);
+                }
+
+                while (decoderThread.TryPeekVideoFrame(out TrackData frameData)
+                   &&  frameData.TrackTime <= decoderThread.Watch.Elapsed)
+                {
+                    if (frameData.LoopCount > decoderThread._prevLoopCount)
+                    {
+                        decoderThread.Watch.Restart();
+                        decoderThread._prevLoopCount = frameData.LoopCount;
+                    }
+
+                    decoderThread._videoFrameQueue.Dequeue();
+                    lock (decoderThread._nextVideoFrameLock)
+                    {
+                        decoderThread._nextVideoFrame = frameData;
+                    }
+                }
+
+                if (reachEndOfStream)
+                {
+                    if (decoderThread._videoFrameQueue.Count < 1
+                    &&  decoderThread._audioFrameQueue.Count < 1)
+                    {
+                        Debug.Assert(videoPlayerStrategy.IsLooped == false);
+
+                        decoderThread._threadState = ThreadState.Stop;
+                        var handler = decoderThread.Stopped;
+                        if (handler != null)
+                            handler(decoderThread, EventArgs.Empty);
+
+                        decoderThread._threadState = ThreadState.Stop;
+                        decoderThread.Watch.Stop();
+                        decoderThread.DecoderProcess.Dispose();
+                        decoderThread.DecoderProcess = null;
+
+                        return;
+                    }
+                }
+
+                Thread.Sleep(0);
+            }
+
+            return;
+        }
+
+        internal bool TryGetNextVideoFrame(out TrackData trackData)
+        {
+            lock (_nextVideoFrameLock)
+            {
+                if (_nextVideoFrame != null
+                &&  _nextVideoFrame.Value.TrackTime <= Watch.Elapsed)
+                {
+                    trackData = _nextVideoFrame.Value;
+                    _nextVideoFrame = null;
+                    return true;
+                }
+                else
+                {
+                    trackData = default(TrackData);
+                    return false;
+                }
+            }
+        }
+
+        public bool TryPeekVideoFrame(out TrackData frameData)
+        {
+            if (_videoFrameQueue.Count > 0)
+            {
+                frameData = _videoFrameQueue.Peek();
+                return true;
+            }
+            frameData = default(TrackData);
+            return false;
+        }
+
+        public bool TryPeekAudioFrame(out TrackData frameData)
+        {
+            if (_audioFrameQueue.Count > 0)
+            {
+                frameData = _audioFrameQueue.Peek();
+                return true;
+            }
+            frameData = default(TrackData);
+            return false;
+        }
+
+        private static string GetFFmpegPath()
+        {
+            switch(Environment.OSVersion.Platform)
+            {
+                case PlatformID.Win32NT:
+                case PlatformID.Win32Windows:
+                    {
+                        string arch = Environment.Is64BitProcess ? "x64" : "x86";
+                        string ffmpegPath = Path.Combine(arch, "ffmpeg.exe");
+                        if (File.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ffmpegPath)))
+                            return ffmpegPath;
+
+                        return "ffmpeg.exe";
+                    }
+                default:
+                    return "ffmpeg";
+            }
+        }
+
+        public void Stop()
+        {
+            _threadState = ThreadState.Stop;
+            _thread.Join();
+            _thread = null;
+
+            Watch.Stop();
+
+            DecoderProcess.Dispose();
+            DecoderProcess = null;
+        }
+    }
+}

--- a/Platforms/Media/DesktopGL/VideoDecoder/FrameBufferPool.cs
+++ b/Platforms/Media/DesktopGL/VideoDecoder/FrameBufferPool.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (C)2024 Nick Kastellanos
+
+using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Xna.Platform.Media
+{
+    public class FrameBufferPool : IComparer<byte[]>
+    {
+        private const int MinimumBufferSize = 0;
+
+        private static readonly FrameBufferPool _current = new FrameBufferPool();
+
+        private SortedSet<byte[]> _bufferSet;
+
+        public FrameBufferPool()
+        {
+            _bufferSet = new SortedSet<byte[]>(this);
+        }
+
+        public byte[] Get(int size)
+        {
+            lock (_bufferSet)
+            {
+                foreach (byte[] buffer in _bufferSet)
+                {
+                    if (buffer.Length == size)
+                    {
+                        _bufferSet.Remove(buffer);
+                        return buffer;
+                    }
+                }
+
+                if (_bufferSet.Count >= 1)
+                    _bufferSet.Remove(_bufferSet.Max);
+
+                int dataSize = Math.Max(MinimumBufferSize, size);
+
+#if NET8_0_OR_GREATER
+                return GC.AllocateUninitializedArray<byte>(dataSize);
+#else
+                return new byte[dataSize];
+#endif
+            }
+        }
+
+        public void Return(byte[] buffer)
+        {
+            lock (_bufferSet)
+            {
+                _bufferSet.Add(buffer);
+            }
+        }
+
+        int IComparer<byte[]>.Compare(byte[] x, byte[] y)
+        {
+            return (x.Length - y.Length);
+        }
+    }
+}

--- a/Platforms/Media/DesktopGL/VideoDecoder/PipeBinaryReader.cs
+++ b/Platforms/Media/DesktopGL/VideoDecoder/PipeBinaryReader.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (C)2025 Nick Kastellanos
+
+using System;
+using System.IO;
+using System.Text;
+
+namespace Microsoft.Xna.Platform.Media
+{
+    internal class PipeBinaryReader : BinaryReader
+    {
+        public long Position { get; private set; }
+
+
+        public PipeBinaryReader(Stream input) : base(input)
+        {
+        }
+
+        public PipeBinaryReader(Stream input, Encoding encoding) : base(input, encoding)
+        {
+        }
+
+        #region overrides
+
+        public override int Read(byte[] buffer, int index, int count)
+        {
+            int readBytes = base.Read(buffer, index, count);
+            Position += readBytes;
+            return readBytes;
+        }
+
+        public override byte[] ReadBytes(int count)
+        {
+            byte[] bytes = base.ReadBytes(count);
+            Position += bytes.Length;
+            return bytes;
+        }
+
+        public override byte ReadByte()
+        {
+            byte value = base.ReadByte();
+            Position++;
+            return value;
+        }
+
+        public override short ReadInt16()
+        {
+            short value = base.ReadInt16();
+            Position+=2;
+            return value;
+        }
+
+        public override uint ReadUInt32()
+        {
+            uint value = base.ReadUInt32();
+            Position+=4;
+            return value;
+        }
+
+        public override float ReadSingle()
+        {
+            float value = base.ReadSingle();
+            Position+=4;
+            return value;
+        }
+
+        public override double ReadDouble()
+        {
+            double value = base.ReadDouble();
+            Position+=8;
+            return value;
+        }
+
+
+        public void SkipBytes(ulong count)
+        {
+            while (count > 0)
+            {
+                int skip = (int)Math.Min(count, 4096);
+                this.ReadBytes(skip);
+                count -= (ulong)skip;
+            }
+        }
+
+        #endregion overrides
+
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+            
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/Platforms/Media/DesktopGL/VideoDecoder/TrackData.cs
+++ b/Platforms/Media/DesktopGL/VideoDecoder/TrackData.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (C)2022 Nick Kastellanos
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Microsoft.Xna.Platform.Media
+{
+    [DebuggerDisplay("TrackTime: {TrackTime}, AbsoluteTimecode: {AbsoluteTimecode}")]
+    internal struct TrackData
+    {
+        public readonly byte[] Data;
+        public readonly TimeSpan TrackTime;
+        public readonly long AbsoluteTimecode;
+        public readonly int LoopCount;
+
+        public TrackData(byte[] frameData, TimeSpan trackTime, long absoluteTimecode)
+        {
+            Data = frameData;
+            TrackTime = trackTime;
+            AbsoluteTimecode = absoluteTimecode;
+            LoopCount = 0;
+        }
+
+        public TrackData(byte[] frameData, TimeSpan trackTime, long absoluteTimecode, int loopCount = 0)
+        {
+            Data = frameData;
+            TrackTime = trackTime;
+            AbsoluteTimecode = absoluteTimecode;
+            LoopCount = loopCount;
+        }
+    }
+}

--- a/Platforms/Media/DesktopGL/VideoDecoder/VideoDecoderProcess.cs
+++ b/Platforms/Media/DesktopGL/VideoDecoder/VideoDecoderProcess.cs
@@ -1,0 +1,657 @@
+// Copyright (C)2022 Nick Kastellanos
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Media;
+
+
+namespace Microsoft.Xna.Platform.Media
+{
+    internal class VideoDecoderProcess : IDisposable
+    {
+        private Process _ffmpegProcess;
+        private StreamReader _outputReader;
+        internal PipeBinaryReader _binaryReader;
+
+        public VideoDecoderProcess(Video video, string ffmpegPath, string inputFile)
+        {
+            int frameSize = video.Width * video.Height * 4; // RBGA
+
+            ProcessStartInfo startInfo = new ProcessStartInfo();
+            startInfo.FileName = ffmpegPath;
+            startInfo.Arguments = $"-i \"{inputFile}\" -c:v rawvideo -c:a pcm_s16le -ar 48000 -pix_fmt rgba -f matroska -";
+
+            startInfo.RedirectStandardOutput = true;
+            startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
+
+            _ffmpegProcess = new Process();
+            _ffmpegProcess.StartInfo = startInfo;
+            _ffmpegProcess.Start();
+
+            _outputReader = _ffmpegProcess.StandardOutput;
+            _binaryReader = new PipeBinaryReader(_outputReader.BaseStream);
+        }
+
+        private MKVElement ReadIDInt(PipeBinaryReader reader)
+        {
+            byte first = reader.ReadByte();
+            int length = 1;
+
+            byte mask = 0x80;
+            while ((first & mask) == 0)
+            {
+                mask >>= 1;
+                length++;
+            }
+
+            ulong value = first;
+            for (int i = 1; i < length; i++)
+            {
+                value = (value << 8) | reader.ReadByte();
+            }
+            return (MKVElement)value;
+        }
+
+        private ulong ReadVInt(PipeBinaryReader reader)
+        {
+            byte first = reader.ReadByte();
+            int length = 1;
+
+            int mask = 0x80;
+            while ((first & mask) == 0)
+            {
+                mask >>= 1;
+                length++;
+            }
+
+            ulong value = (ulong)(first & (mask - 1));
+            for (int i = 1; i < length; i++)
+            {
+                value = (value << 8) | reader.ReadByte();
+            }
+
+            return value;
+        }
+
+        private ulong ReadUInt(PipeBinaryReader reader, int size)
+        {
+            ulong value = 0;
+            for (int i = 0; i < size; i++)
+            {
+                value = (value << 8) | reader.ReadByte();
+            }
+            return value;
+        }
+
+        private unsafe double ReadFInt(PipeBinaryReader reader, ulong size)
+        {
+            switch (size)
+            {
+                case 8:
+                    ulong raw64 = ReadUInt(reader, 8);
+                    return *((double*)&raw64);
+                case 4:
+                    uint raw32 = (uint)ReadUInt(reader, 4);
+                    return *((float*)&raw32);
+
+                default:
+                    throw new InvalidOperationException();
+            }
+        }
+
+
+        enum MKVElement
+        {
+            EBMLHeader  = 0x1A45DFA3,
+
+            Segment     = 0x18538067,
+            
+            SeekHead    = 0x114D9B74,
+            Info        = 0x1549A966,
+            InfoTimestampScale = 0x2AD7B1,
+
+            Tracks      = 0x1654AE6B,
+            TrackEntry  = 0xAE,
+            TrackNumber = 0xD7,
+            TrackType   = 0x83,
+            TrackUID    = 0x73C5,
+            TrackLanguage = 0x22B59C,
+            TrackCodecID  = 0x86,
+            TrackDefaultDuration = 0x23E383,
+            TrackVideoSettings = 0xE0,
+            TrackAudioSettings = 0xE1,
+            TrackCodecPrivate  = 0x63A2,
+
+            TrackAudioSettingsChannels = 0x9F,
+            TrackAudioSettingsSamplingFrequency = 0xB5,
+
+            TrackVideoSettingsPixelWidth    = 0xB0,
+            TrackVideoSettingsPixelHeight   = 0xBA,
+            TrackVideoSettingsDisplayWidth  = 0x54B0,
+            TrackVideoSettingsDisplayHeight = 0x54BA,
+            TrackVideoSettingsUncompressedFourCC = 0x2EB524,
+
+            Cluster     = 0x1F43B675,
+            Timecode    = 0xE7,
+            SimpleBlock = 0xA3,
+        }
+
+        internal enum MKVTrackType
+        {
+            Video    = 0x01,
+            Audio    = 0x02,
+            Subtitle = 0x11,
+        }
+
+        [Flags]
+        enum SimpleBlockFlags
+        {
+            Keyframe    = 0x80,
+            Invisible   = 0x08,
+            LacingNone  = 0x00,
+            LacingXiph  = 0x02,
+            LacingFixed = 0x04,
+            LacingEBML  = 0x06,
+        };
+
+        public struct MKVAudioSettings
+        {
+            public int Channels;
+            public double SamplingFrequency;
+        }
+
+        public struct MKVVideoSettings
+        {
+            public int PixelWidth;
+            public int PixelHeight;
+            public int DisplayWidth;
+            public int DisplayHeight;
+            public int FourCC;
+        }
+
+        internal class MKVAudioTrack : MKVTrack
+        {
+            public readonly MKVAudioSettings AudioSettings;
+
+            public MKVAudioTrack(MKVTrackType type, MKVAudioSettings audioSettings) : base(type)
+            {
+                AudioSettings = audioSettings;
+            }
+        }
+
+        internal class MKVVideoTrack : MKVTrack
+        {
+            public readonly MKVVideoSettings VideoSettings;
+
+            public MKVVideoTrack(MKVTrackType type, MKVVideoSettings videoSettings) : base(type)
+            {
+                VideoSettings = videoSettings;
+            }
+        }        
+
+        internal class MKVTrack
+        {
+            public readonly MKVTrackType Type;
+
+            public MKVTrack(MKVTrackType type)
+            {
+                Type = type;
+            }
+        }
+
+        struct EBMLElementHeader
+        {
+            public MKVElement Id;
+            public ulong Size;
+        }
+
+        private ulong _timestampScale = 1000000;
+
+        internal Dictionary<int, MKVTrack> _tracks = new Dictionary<int, MKVTrack>();
+
+
+        internal void ParseMKV(Queue<TrackData> _videoFrameQueue, Queue<TrackData> audioFrameQueue,
+                               FrameBufferPool videoFramePool, FrameBufferPool audioFramePool, int loopCount)
+        {
+            ReadEBMLElement(_binaryReader);
+            EBMLElementHeader segmentElementHdr = ReadSegmentStart(_binaryReader);
+            EBMLElementHeader clusterHdr = ParseSegmentTracks(_binaryReader, (long)segmentElementHdr.Size);
+
+            // parse first cluster
+            if (clusterHdr.Id == MKVElement.Cluster)
+                ParseCluster(_binaryReader, (long)clusterHdr.Size, _videoFrameQueue, audioFrameQueue, videoFramePool, audioFramePool, loopCount);
+
+            while (_videoFrameQueue.Count < 1)
+                ParseSegmentCluster2(_binaryReader, (long)segmentElementHdr.Size, _videoFrameQueue, audioFrameQueue, videoFramePool, audioFramePool, loopCount);
+        }
+
+        private EBMLElementHeader ReadSegmentStart(PipeBinaryReader reader)
+        {
+            while (true)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                if (elementHdr.Id == MKVElement.Segment)
+                {
+                    return elementHdr;
+                }
+                else // unknown element
+                {
+                    reader.SkipBytes(elementHdr.Size);
+                }
+            }
+        }
+
+        private void ReadEBMLElement(PipeBinaryReader reader)
+        {
+            EBMLElementHeader emblElementHdr = ReadElementHeader(reader);
+            if (emblElementHdr.Id != MKVElement.EBMLHeader)
+                throw new InvalidDataException("Expected EBML Header (0x1A45DFA3)");
+            reader.SkipBytes(emblElementHdr.Size);
+        }
+
+        private EBMLElementHeader ReadElementHeader(PipeBinaryReader reader)
+        {
+            EBMLElementHeader header;
+            header.Id   = ReadIDInt(reader);
+            header.Size = ReadVInt(reader);
+            return header;
+        }
+
+        /// <returns>Cluster ElementHeader</returns>
+        private EBMLElementHeader ParseSegmentTracks(PipeBinaryReader reader, long segmentSize)
+        {
+            long start = reader.Position;
+
+            while (reader.Position < start + segmentSize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                long dataPosition = reader.Position;
+
+                Debug.WriteLine($"  Segment element ID: {elementHdr.Id:X}, Size: {elementHdr.Size}");
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.Info:
+                        ParseTracksInfo(reader, (long)elementHdr.Size);
+                        break;
+
+                    case MKVElement.Tracks:
+                        ParseTracks(reader, (long)elementHdr.Size);
+                        break;
+                    case MKVElement.Cluster:
+                        return elementHdr;
+
+                    case MKVElement.SeekHead:
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+
+            return new EBMLElementHeader();
+        }
+
+        private void ParseTracksInfo(PipeBinaryReader reader, long infoSize)
+        {
+            long start = reader.Position;
+
+            while (reader.Position < start + infoSize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+                long dataPosition = reader.Position;
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.InfoTimestampScale:
+                        _timestampScale = ReadUInt(reader, (int)elementHdr.Size);
+                        Debug.Assert(_timestampScale != 0);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+        }
+
+        private void ParseTracks(PipeBinaryReader reader, long trackSize)
+        {
+            long start = reader.Position;
+
+            while (reader.Position < start + trackSize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+                long dataPosition = reader.Position;
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.TrackEntry:
+                        ParseTrackEntry(reader, (long)elementHdr.Size);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+        }
+
+        private void ParseTrackEntry(PipeBinaryReader reader, long entrySize)
+        {
+            long start = reader.Position;
+
+            int trackNumber = -1;
+            MKVTrackType trackType = (MKVTrackType)(-1);
+            MKVAudioSettings audioSettings;
+            audioSettings.Channels = 1;
+            audioSettings.SamplingFrequency = 8000;
+            MKVVideoSettings videoSettings = default;
+
+            while (reader.Position < start + entrySize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.TrackNumber:
+                        trackNumber = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackType:
+                        Debug.Assert(elementHdr.Size == 1);
+                        trackType = (MKVTrackType)reader.ReadByte();
+                        break;
+                    case MKVElement.TrackAudioSettings:
+                        audioSettings = ParseTrackAudioSettings(reader, (long)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackVideoSettings:
+                        videoSettings = ParseTrackVideoSettings(reader, (long)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackDefaultDuration:
+                        // Number of nanoseconds per frame, expressed in Matroska Ticks
+                        int defaultDuration = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+
+                    case MKVElement.TrackUID:
+                    case MKVElement.TrackLanguage:
+                    case MKVElement.TrackCodecID:
+                    case MKVElement.TrackCodecPrivate:
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+
+            if (trackNumber != -1)
+            {
+                switch (trackType)
+                {
+                    case MKVTrackType.Audio:
+                        _tracks[trackNumber] = new MKVAudioTrack(trackType, audioSettings);
+                        break;
+
+                    default:
+                        _tracks[trackNumber] = new MKVVideoTrack(trackType, videoSettings);
+                        break;
+                }
+            }
+
+            Debug.WriteLine($"Track Number: {trackNumber}, Type: {(trackType == MKVTrackType.Video ? "Video" : trackType == MKVTrackType.Audio ? "Audio" : "Other")}");
+        }
+
+        private MKVAudioSettings ParseTrackAudioSettings(PipeBinaryReader reader, long size)
+        {
+            long start = reader.Position;
+
+            MKVAudioSettings audioSettings;
+            audioSettings.Channels = 1;
+            audioSettings.SamplingFrequency = 8000;
+
+            while (reader.Position < start + size)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.TrackAudioSettingsChannels:
+                        audioSettings.Channels = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackAudioSettingsSamplingFrequency:
+                        audioSettings.SamplingFrequency = ReadFInt(reader, elementHdr.Size);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+
+            return audioSettings;
+        }
+
+        private MKVVideoSettings ParseTrackVideoSettings(PipeBinaryReader reader, long size)
+        {
+            long start = reader.Position;
+
+            MKVVideoSettings videoSettings = default;
+
+            while (reader.Position < start + size)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.TrackVideoSettingsPixelWidth: 
+                        videoSettings.PixelWidth = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackVideoSettingsPixelHeight:
+                        videoSettings.PixelHeight = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackVideoSettingsDisplayWidth:
+                        videoSettings.DisplayWidth = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackVideoSettingsDisplayHeight:
+                        videoSettings.DisplayHeight = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+                    case MKVElement.TrackVideoSettingsUncompressedFourCC:
+                        videoSettings.FourCC = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+
+            return videoSettings;
+        }
+
+        private void ParseSegmentCluster(PipeBinaryReader reader, long segmentSize,
+            Queue<TrackData> videoFrameQueue, Queue<TrackData> audioFrameQueue,
+            FrameBufferPool videoFramePool, FrameBufferPool audioFramePool, int loopCount)
+        {
+            long start = reader.Position;
+
+            while (reader.Position < start + segmentSize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                long dataPosition = reader.Position;
+
+                Debug.WriteLine($"  Segment element ID: {elementHdr.Id:X}, Size: {elementHdr.Size}");
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.Cluster:
+                        ParseCluster(reader, (long)elementHdr.Size, videoFrameQueue, audioFrameQueue, videoFramePool, audioFramePool, loopCount);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+        }
+
+        internal void ParseSegmentCluster2(PipeBinaryReader reader, long segmentSize,
+            Queue<TrackData> videoFrameQueue, Queue<TrackData> audioFrameQueue,
+            FrameBufferPool videoFramePool, FrameBufferPool audioFramePool, int loopCount)
+        {
+            long start = reader.Position;
+
+            EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+            long dataPosition = reader.Position;
+
+            Debug.WriteLine($"  Segment element ID: {elementHdr.Id:X}, Size: {elementHdr.Size}");
+
+            switch (elementHdr.Id)
+            {
+                case MKVElement.Cluster:
+                    ParseCluster(reader, (long)elementHdr.Size, videoFrameQueue, audioFrameQueue, videoFramePool, audioFramePool, loopCount);
+                    break;
+
+                default:
+                    reader.SkipBytes(elementHdr.Size);
+                    break;
+            }
+        }
+
+        private void ParseCluster(PipeBinaryReader reader, long clusterSize,
+            Queue<TrackData> videoFrameQueue, Queue<TrackData> audioFrameQueue,
+            FrameBufferPool videoFramePool, FrameBufferPool audioFramePool, int loopCount)
+        {
+            long start = reader.Position;
+            int clusterTimecode = 0;
+
+            while (reader.Position < start + clusterSize)
+            {
+                EBMLElementHeader elementHdr = ReadElementHeader(reader);
+
+                long dataPosition = reader.Position;
+
+                switch (elementHdr.Id)
+                {
+                    case MKVElement.Timecode:
+                        clusterTimecode = (int)ReadUInt(reader, (int)elementHdr.Size);
+                        Debug.WriteLine($"Cluster timecode: {clusterTimecode}");
+                        break;
+                    case MKVElement.SimpleBlock:
+                        ParseSimpleBlock(reader, (long)elementHdr.Size, clusterTimecode,
+                            videoFrameQueue, audioFrameQueue,
+                            videoFramePool, audioFramePool, loopCount);
+                        break;
+
+                    default:
+                        reader.SkipBytes(elementHdr.Size);
+                        break;
+                }
+            }
+        }
+
+        private void ParseSimpleBlock(PipeBinaryReader reader, long blockSize, int clusterTimecode,
+            Queue<TrackData> videoFrameQueue, Queue<TrackData> audioFrameQueue,
+            FrameBufferPool videoFramePool, FrameBufferPool audioFramePool, int loopCount)
+        {
+            long blockStart = reader.Position;
+
+            ulong trackNumber = ReadVInt(reader);
+            ushort blockTimecode = (ushort)ReadUInt(reader, 2);
+            SimpleBlockFlags flags = (SimpleBlockFlags)reader.ReadByte();
+
+            long frameDataSize = blockSize -(reader.Position - blockStart);
+
+            int absoluteTimecode = clusterTimecode + blockTimecode;
+            TimeSpan trackTime = TimeSpan.FromTicks(absoluteTimecode * (long)_timestampScale * TimeSpan.TicksPerSecond / 1_000_000_000L);
+
+            MKVTrack track = _tracks[(int)trackNumber];
+            switch (track.Type)
+            {
+                case MKVTrackType.Video:
+                    {
+                        MKVVideoTrack videoTrack = (MKVVideoTrack)track;
+                        byte[] frameData = videoFramePool.Get((int)frameDataSize);
+                        TrackData trackData = new TrackData(frameData, trackTime, (long)absoluteTimecode, loopCount);
+                        ReadVideoFrame(frameDataSize, videoTrack.VideoSettings, trackData.Data);
+                        videoFrameQueue.Enqueue(trackData);
+                    }
+                    break;
+                case MKVTrackType.Audio:
+                    {
+                        MKVAudioTrack audioTrack = (MKVAudioTrack)track;
+                        byte[] frameData = audioFramePool.Get((int)frameDataSize);
+                        TrackData trackData = new TrackData(frameData, trackTime, (long)absoluteTimecode, loopCount);
+                        ReadAudioFrame(frameDataSize, audioTrack.AudioSettings, trackData.Data);
+                        audioFrameQueue.Enqueue(trackData);
+                    }
+                    break;
+
+                case MKVTrackType.Subtitle:
+                default:
+                    reader.SkipBytes((ulong)frameDataSize);
+                    break;
+            }
+
+
+            Debug.WriteLine($"  SimpleBlock -> Track: {trackNumber}, TrackType: {track.Type}, AbsTime: {absoluteTimecode}, blockTimecode: {blockTimecode}, Keyframe: {(flags & SimpleBlockFlags.Keyframe) != 0}, Size: {frameDataSize}");
+        }
+
+        public void ReadVideoFrame(long videoFrameDataSize, MKVVideoSettings videoSettings, byte[] frameData)
+        {
+            int totalBytesRead = 0;
+            while (totalBytesRead < frameData.Length)
+            {
+                int bytesRead = _binaryReader.Read(frameData, totalBytesRead, frameData.Length - totalBytesRead);
+                totalBytesRead += bytesRead;
+            }
+        }
+
+        public void ReadAudioFrame(long audioFrameDataSize, MKVAudioSettings audioSettings, byte[] frameData)
+        {
+            int totalBytesRead = 0;
+            while (totalBytesRead < frameData.Length)
+            {
+                int bytesRead = _binaryReader.Read(frameData, totalBytesRead, frameData.Length - totalBytesRead);
+                totalBytesRead += bytesRead;
+                //if (bytesRead == 0)
+                //    return;
+            }
+            return;
+
+            int audioFrameSize = ((int)audioSettings.SamplingFrequency / 30) * (int)audioSettings.Channels * 2;
+
+        }
+
+        #region IDisposable Members
+
+        ~VideoDecoderProcess()
+        {
+            Dispose(false);
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+            }
+
+            _ffmpegProcess.Kill();
+            _ffmpegProcess.Dispose();
+
+            _binaryReader.Dispose();
+            _outputReader.Dispose();
+
+        }
+        #endregion
+    }
+}


### PR DESCRIPTION
This is using FFmpeg to decode video.

The FFmpeg executables are not added to the SDL2.GL templates.
Devs should include their own build of FFmpeg to the project.

The executable should be placed at \x64\FFmpeg.exe for Windows, and in the root folder for unix/macOS.
