### PR TITLE
x64 SDK installer

### DIFF
--- a/Installers/Windows/KniSdkSetup.nsi
+++ b/Installers/Windows/KniSdkSetup.nsi
@@ -44,7 +44,7 @@ Page Custom SponsorPage SponsorPageLeave
  
 Name '${APPNAME} SDK ${INSTALLERVERSION}'
 OutFile 'KniSdkSetup.exe'
-InstallDir '$PROGRAMFILES\${APPNAME}\v${VERSION}'
+InstallDir '$PROGRAMFILES64\${APPNAME}\v${VERSION}'
 VIProductVersion "${INSTALLERVERSION}"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "${APPNAME} SDK"
 VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "Kni framework"


### PR DESCRIPTION
this places the SDK in C:\Program Files, instead of C:\Program Files (x86)