### PR TITLE
fix ContentTypeReaderManager FileLoadException

### DIFF
--- a/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
+++ b/src/Xna.Framework.Content/Content/ContentTypeReaderManager.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Text.RegularExpressions;
 using System.Collections.Generic;
+using System.IO;
 using Microsoft.Xna.Platform.Content.Utilities;
 
 namespace Microsoft.Xna.Framework.Content
@@ -246,15 +247,18 @@ namespace Microsoft.Xna.Framework.Content
             if (readerType != null)
                 return readerType;
             resolvedReaderTypeName = readerTypeName + string.Format(", {0}", _contentGraphicsAssemblyName);
-            readerType = Type.GetType(resolvedReaderTypeName);
+            try { readerType = Type.GetType(resolvedReaderTypeName); }
+            catch(FileLoadException) { /* ignore */ }
             if (readerType != null)
                 return readerType;
             resolvedReaderTypeName = readerTypeName + string.Format(", {0}", _contentAudioAssemblyName);
-            readerType = Type.GetType(resolvedReaderTypeName);
+            try { readerType = Type.GetType(resolvedReaderTypeName); }
+            catch(FileLoadException) { /* ignore */ }
             if (readerType != null)
                 return readerType;
             resolvedReaderTypeName = readerTypeName + string.Format(", {0}", _contentMediaAssemblyName);
-            readerType = Type.GetType(resolvedReaderTypeName);
+            try { readerType = Type.GetType(resolvedReaderTypeName); }
+            catch(FileLoadException) { /* ignore */ }
             if (readerType != null)
                 return readerType;
 


### PR DESCRIPTION
the affected code is trying to resolve cases, where XNA produces readerTypeName with the Type only without the assembly, and which KNI also emulates. If a readerTypeName contain an assembly, it should already be resolved. But if the user didn't reference the TypeReader, or the name was changed and tries to load an old XNB, then those generate an invalid resolvedReaderTypeName and throw a FileLoadException with a crypting error message . 

eg. "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended" -->    "MonoGame.Extended.Tilemaps.Content.TilemapWorldReader, MonoGame.Extended, Xna.Framework.Graphics" 

FileLoadException = "MonoGame.Extended, Xna.Framework.Graphics"