### PR TITLE
Add GraphicsDevice.InvalidateState() for sharing a GL context with an external renderer

### DIFF
--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -165,7 +165,7 @@ namespace Microsoft.Xna.Platform.Graphics
         //    sets the same BlendState/DepthStencilState/RasterizerState object it used last frame
         //    (very common - e.g. reusing BlendState.Opaque), those property setters return early on
         //    reference equality and never reach #1. Force them dirty so the next draw checks for real.
-        public override void InvalidateStateCache()
+        public override void InvalidateState()
         {
             ((IPlatformBlendState)base._actualBlendState).GetStrategy<ConcreteBlendState>().PlatformApplyState(this, true);
             ((IPlatformDepthStencilState)base._actualDepthStencilState).GetStrategy<ConcreteDepthStencilState>().PlatformApplyState(this, true);

--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -184,6 +184,10 @@ namespace Microsoft.Xna.Platform.Graphics
             _shaderProgram = null;
             _lastVertexAttribs = 0; // 0 = dirty, forces a rebind on the next draw.
 
+            // Mirrors real GL enabled-attribute state; an external EnableVertexAttribArray/
+            // DisableVertexAttribArray call makes this stale, so clear it rather than trust it.
+            _enabledVertexAttributesSet.Clear();
+
             ((IPlatformTextureCollection)this.Textures).Strategy.Dirty();
             ((IPlatformTextureCollection)this.VertexTextures).Strategy.Dirty();
         }

--- a/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs
@@ -155,6 +155,39 @@ namespace Microsoft.Xna.Platform.Graphics
             BlendState = prevBlendState;
         }
 
+        // Something else drew into this GL context behind our back (e.g. a library sharing the
+        // context instead of using its own canvas). Two things need clearing, not one:
+        //
+        // 1. The state KNI thinks it already pushed to the GPU (_lastBlendState etc, checked by
+        //    ConcreteBlendState/ConcreteDepthStencilState/ConcreteRasterizerState.PlatformApplyState).
+        //    Re-apply it right now instead of waiting.
+        // 2. The dirty flags that decide whether KNI looks at that state again at all. If the app
+        //    sets the same BlendState/DepthStencilState/RasterizerState object it used last frame
+        //    (very common - e.g. reusing BlendState.Opaque), those property setters return early on
+        //    reference equality and never reach #1. Force them dirty so the next draw checks for real.
+        public override void InvalidateStateCache()
+        {
+            ((IPlatformBlendState)base._actualBlendState).GetStrategy<ConcreteBlendState>().PlatformApplyState(this, true);
+            ((IPlatformDepthStencilState)base._actualDepthStencilState).GetStrategy<ConcreteDepthStencilState>().PlatformApplyState(this, true);
+            ((IPlatformRasterizerState)base._actualRasterizerState).GetStrategy<ConcreteRasterizerState>().PlatformApplyState(this, true);
+
+            _blendStateDirty = true;
+            _blendFactorDirty = true;
+            _depthStencilStateDirty = true;
+            _rasterizerStateDirty = true;
+            _scissorRectangleDirty = true;
+            _vertexShaderDirty = true;
+            _pixelShaderDirty = true;
+            _indexBufferDirty = true;
+            _vertexBuffersDirty = true;
+
+            _shaderProgram = null;
+            _lastVertexAttribs = 0; // 0 = dirty, forces a rebind on the next draw.
+
+            ((IPlatformTextureCollection)this.Textures).Strategy.Dirty();
+            ((IPlatformTextureCollection)this.VertexTextures).Strategy.Dirty();
+        }
+
         private void PlatformApplyState()
         {
             //this.EnsureContextCurrentThread();

--- a/Platforms/Graphics/.DX11/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.DX11/ConcreteGraphicsContext.cs
@@ -695,6 +695,11 @@ namespace Microsoft.Xna.Platform.Graphics
             this.D3dContext.Flush();
         }
 
+        public override void InvalidateState()
+        {
+            throw new NotImplementedException();
+        }
+
 
         public override OcclusionQueryStrategy CreateOcclusionQueryStrategy()
         {

--- a/Platforms/Graphics/.GL/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.GL/ConcreteGraphicsContext.cs
@@ -1099,6 +1099,11 @@ namespace Microsoft.Xna.Platform.Graphics
             GL.Flush();
         }
 
+        public override void InvalidateState()
+        {
+            throw new NotImplementedException();
+        }
+
 
         public override OcclusionQueryStrategy CreateOcclusionQueryStrategy()
         {

--- a/Platforms/Graphics/.Ref/ConcreteGraphicsContext.cs
+++ b/Platforms/Graphics/.Ref/ConcreteGraphicsContext.cs
@@ -101,6 +101,11 @@ namespace Microsoft.Xna.Platform.Graphics
             throw new PlatformNotSupportedException();
         }
 
+        public override void InvalidateState()
+        {
+            throw new PlatformNotSupportedException();
+        }
+
 
         public override OcclusionQueryStrategy CreateOcclusionQueryStrategy()
         {

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsContext.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsContext.cs
@@ -146,6 +146,11 @@ namespace Microsoft.Xna.Framework.Graphics
             _strategy.Clear(options, color, depth, stencil);
         }
 
+        public void InvalidateStateCache()
+        {
+            _strategy.InvalidateStateCache();
+        }
+
         public void SetVertexBuffer(VertexBuffer vertexBuffer)
         {
             _strategy.SetVertexBuffer(vertexBuffer);

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsContext.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsContext.cs
@@ -146,9 +146,9 @@ namespace Microsoft.Xna.Framework.Graphics
             _strategy.Clear(options, color, depth, stencil);
         }
 
-        public void InvalidateStateCache()
+        public void InvalidateState()
         {
-            _strategy.InvalidateStateCache();
+            _strategy.InvalidateState();
         }
 
         public void SetVertexBuffer(VertexBuffer vertexBuffer)

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsContextStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsContextStrategy.cs
@@ -588,11 +588,10 @@ namespace Microsoft.Xna.Platform.Graphics
             return (T)this;
         }
 
-        // No-op by default. Override where an external renderer can draw into the same GPU context
-        // KNI is using - see Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs.
-        public virtual void InvalidateStateCache()
-        {
-        }
+        // Called when an external renderer has drawn into the same GPU context KNI is using, so the
+        // next draw cannot trust anything it thinks is already bound. Implemented on BlazorGL, see
+        // Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs.
+        public abstract void InvalidateState();
 
         #region Metrics
         protected void Metrics_AddClearCount() { unchecked { _graphicsMetrics._clearCount++; } }

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsContextStrategy.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsContextStrategy.cs
@@ -588,6 +588,12 @@ namespace Microsoft.Xna.Platform.Graphics
             return (T)this;
         }
 
+        // No-op by default. Override where an external renderer can draw into the same GPU context
+        // KNI is using - see Platforms/Graphics/.BlazorGL/ConcreteGraphicsContext.cs.
+        public virtual void InvalidateStateCache()
+        {
+        }
+
         #region Metrics
         protected void Metrics_AddClearCount() { unchecked { _graphicsMetrics._clearCount++; } }
         protected void Metrics_AddDrawCount() { unchecked { _graphicsMetrics._drawCount++; } }

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsDevice.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsDevice.cs
@@ -277,10 +277,10 @@ namespace Microsoft.Xna.Framework.Graphics
         // SkiaSharp is one). It forces the next draw call to rebind everything - shader, textures,
         // buffers, blend/depth/rasterizer state - instead of trusting what's already bound.
         //
-        // Only does anything on BlazorGL right now. A no-op everywhere else.
-        public void InvalidateStateCache()
+        // Only implemented on BlazorGL right now. Throws on the other backends.
+        public void InvalidateState()
         {
-            CurrentContext.InvalidateStateCache();
+            CurrentContext.InvalidateState();
         }
 
         public void Dispose()

--- a/src/Xna.Framework.Graphics/Graphics/GraphicsDevice.cs
+++ b/src/Xna.Framework.Graphics/Graphics/GraphicsDevice.cs
@@ -272,6 +272,17 @@ namespace Microsoft.Xna.Framework.Graphics
             CurrentContext.Clear(options, color, depth, stencil);
         }
 
+        // Call this after some other code has drawn into this GraphicsDevice's GPU context directly
+        // (for example, a rendering library sharing the context instead of using its own canvas -
+        // SkiaSharp is one). It forces the next draw call to rebind everything - shader, textures,
+        // buffers, blend/depth/rasterizer state - instead of trusting what's already bound.
+        //
+        // Only does anything on BlazorGL right now. A no-op everywhere else.
+        public void InvalidateStateCache()
+        {
+            CurrentContext.InvalidateStateCache();
+        }
+
         public void Dispose()
         {
             Dispose(true);


### PR DESCRIPTION
If something else draws into the same GL context KNI is using - for example SkiaSharp sharing the context instead of using its own canvas - KNI's next draw comes out wrong, or throws GL_INVALID_OPERATION. KNI still thinks its cached blend/depth/rasterizer state, shader, bound textures, and buffers match the GPU. They don't anymore.

Add `GraphicsDevice.InvalidateState()`. Call it once after the external renderer is done, before KNI draws again. It re-applies KNI's blend/depth/rasterizer state right now, and marks the shader/buffers/textures/scissor dirty so the next draw actually rebinds them instead of skipping the rebind because the state object didn't change.

Implemented on BlazorGL, the only backend I tested. `GraphicsContextStrategy.InvalidateState()` is abstract rather than a virtual no-op, so every backend answers for itself instead of silently ignoring the call: DX11 and GL throw `NotImplementedException`, Ref throws `PlatformNotSupportedException`.

**Tested:** draw with KNI, hand the same WebGL2 context to another renderer, have KNI draw again. Without this: GL_INVALID_OPERATION, wrong pixels. With this: correct pixels, no GL error. Checked at 1920x1080, 2560x1440, 3840x2160, in Chrome and Firefox, on real hardware.

Builds verified on Windows: `Xna.Framework.Graphics`, `Kni.Platform.Ref`, `Kni.Platform.WinForms.DX11`, `Kni.Platform.Blazor.GL`, and `Kni.Platform.SDL2.GL` (C# compiles clean; only its native-dependency copy step fails locally). Android, iOS and UAP were not built here, but they inherit the new method from `ConcreteGraphicsContextGL` and the DX11 strategy respectively.
