### PR TITLE
Add GraphicsWebGLExtensions for the BlazorGL WebGL context and texture handles

### DIFF
--- a/Platforms/Graphics/.BlazorGL/GraphicsWebGLExtensions.cs
+++ b/Platforms/Graphics/.BlazorGL/GraphicsWebGLExtensions.cs
@@ -1,0 +1,35 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using Microsoft.Xna.Platform.Graphics;
+using nkast.Wasm.Canvas.WebGL;
+
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    static public class GraphicsWebGLExtensions
+    {
+        /// <summary>
+        /// Returns a handle to the internal WebGL rendering context. Valid only on Blazor platforms.
+        /// For usage, convert this to nkast.Wasm.Canvas.WebGL.IWebGLRenderingContext.
+        /// </summary>
+        public static object GetWebGLContext(this GraphicsDevice device)
+        {
+            GraphicsContext context = ((IPlatformGraphicsDevice)device).Strategy.CurrentContext;
+            IWebGLRenderingContext glContext = ((IPlatformGraphicsContext)context).Strategy.ToConcrete<ConcreteGraphicsContext>().GL;
+            return glContext;
+        }
+
+        /// <summary>
+        /// Returns a handle to the internal WebGL texture object. Valid only on Blazor platforms.
+        /// For usage, convert this to nkast.Wasm.Canvas.WebGL.WebGLTexture.
+        /// </summary>
+        public static object GetWebGLTexture(this Texture texture)
+        {
+            WebGLTexture glTexture = ((IPlatformTexture)texture).GetTextureStrategy<ConcreteTexture>()._glTexture;
+            return glTexture;
+        }
+    }
+}

--- a/Platforms/Kni.Platform.Blazor.GL.csproj
+++ b/Platforms/Kni.Platform.Blazor.GL.csproj
@@ -150,6 +150,7 @@
     <Compile Include="Graphics\.BlazorGL\ConcreteSamplerStateCollection.cs" />
     <Compile Include="Graphics\.BlazorGL\ConcreteTextureCollection.cs" />
     <Compile Include="Graphics\.BlazorGL\GLExtensions.cs" />
+    <Compile Include="Graphics\.BlazorGL\GraphicsWebGLExtensions.cs" />
     <Compile Include="Graphics\.BlazorGL\IRenderTargetStrategyGL.cs" />
 
     <Compile Include="Graphics\.Common\SpriteBatcher.cs" />


### PR DESCRIPTION
Follow-up to #2710, split out as discussed there.

SkiaGameRendering needs the WebGL rendering context and the `WebGLTexture` behind a `Texture2D`, so it can pass their `.Uid` down to JS and upload a browser canvas straight into a KNI texture. Today it reads both by reflection into `ConcreteGraphicsContext.GL` and `ConcreteTexture._glTexture`, which breaks silently on a rename.

Adds `GraphicsWebGLExtensions` with `GetWebGLContext()` and `GetWebGLTexture()`, same shape as `GraphicsSharpDXExtensions` on DX11: an extension class inside the platform assembly, so the API only exists for code that already references `Kni.Platform.Blazor.GL`, and returning `object` so the public signature does not pin the `nkast.Wasm.Canvas` types.

`GetWebGLTexture` hangs off `Texture` rather than `Texture2D`, matching `GetD3D11Resource`, so render targets are covered too.

Builds clean on `Kni.Platform.Blazor.GL`.
